### PR TITLE
feat: improve empty string behavior #58

### DIFF
--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -318,4 +318,36 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    pub struct EmptyStringTestData0 {
+        #[raiden(partition_key)]
+        #[raiden(uuid)]
+        id: String,
+        name: String,
+    }
+
+    #[test]
+    fn test_get_empty_string() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = EmptyStringTestData0::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+
+            let res = client.get("id0").run().await;
+            assert_eq!(
+                res.unwrap(),
+                get::GetOutput {
+                    item: EmptyStringTestData0 {
+                        id: "id0".to_owned(),
+                        name: "".to_owned(),
+                    },
+                    consumed_capacity: None,
+                }
+            );
+        }
+        rt.block_on(example());
+    }
 }

--- a/raiden/tests/all/put.rs
+++ b/raiden/tests/all/put.rs
@@ -359,4 +359,30 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[derive(Raiden, Debug, Clone)]
+    pub struct EmptyStringTestData0 {
+        #[raiden(partition_key)]
+        #[raiden(uuid)]
+        id: String,
+        name: String,
+    }
+
+    #[test]
+    fn test_put_with_empty_string() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = EmptyStringTestData0::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let item = EmptyStringTestData0::put_item_builder()
+                .name("".to_owned())
+                .build()
+                .unwrap();
+            let res = client.put(item).run().await;
+            assert_eq!(res.is_ok(), true);
+        }
+        rt.block_on(example());
+    }
 }

--- a/setup/index.js
+++ b/setup/index.js
@@ -394,4 +394,19 @@ const put = (params) =>
       sset: { SS: ['Hello'] },
     },
   });
+
+  await createTable({
+    TableName: 'EmptyStringTestData0',
+    KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
+    AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  });
+
+  await put({
+    TableName: 'EmptyStringTestData0',
+    Item: {
+      id: { S: 'id0' },
+      name: { NULL: true },
+    },
+  });
 })();


### PR DESCRIPTION
## What does this change?

#58 improve empty string behavior.
If string is empty, raiden replace it to `NULL`.

``` Rust
impl IntoAttribute for String {
    fn into_attr(self: Self) -> AttributeValue {
        if self == "" {
            // See. https://github.com/raiden-rs/raiden-dynamo/issues/58
            return AttributeValue {
                null: Some(true),
                ..Default::default()
            };
        }
        AttributeValue {
            s: Some(self),
            ..AttributeValue::default()
        }
    }
}

impl FromAttribute for String {
    fn from_attr(value: Option<AttributeValue>) -> Result<Self, ()> {
        if value.is_none() {
            return Err(());
        }
        let value = value.unwrap();
        if let Some(true) = value.null {
            // See. https://github.com/raiden-rs/raiden/issues/58
            return Ok("".to_owned());
        }
        value.s.ok_or((/* TODO: Add convert error handling */))
    }
}
```

## References

NA

## Screenshots

NA

## What can I check for bug fixes?

NA
