### PR TITLE
fix: use delete expression when default attribute value

### DIFF
--- a/raiden/src/update_expression/set.rs
+++ b/raiden/src/update_expression/set.rs
@@ -133,7 +133,7 @@ impl<T: super::IntoAttrName> UpdateSetExpressionBuilder for SetExpressionFilledW
             SetValue::Value(placeholder, value) => {
                 // See. https://github.com/raiden-rs/raiden/issues/57
                 //      https://github.com/raiden-rs/raiden/issues/58
-                if value.null.is_some() || value == AttributeValue::default() {
+                if value == AttributeValue::default() {
                     // Use remove instead of set
                     return SetOrRemove::Remove(attr_name, names);
                 }

--- a/raiden/tests/all/update.rs
+++ b/raiden/tests/all/update.rs
@@ -358,4 +358,25 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[test]
+    fn test_update_to_empty_string() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = User::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let set_name_expression = User::update_expression().set(User::name()).value("");
+            let res = client
+                .update("id0")
+                .set(set_name_expression)
+                .return_all_new()
+                .run()
+                .await
+                .unwrap();
+            assert_eq!(res.item.unwrap().name, "".to_owned(),);
+        }
+        rt.block_on(example());
+    }
 }


### PR DESCRIPTION
## What does this change?

Remove `value.null.is_some()` from delete condition.
A convert error caused by this condtion.
This is because if you write `Set` expression to empty string, string field is deleted by `Delete` expression.

## References

NA

## Screenshots

NA

## What can I check for bug fixes?

https://github.com/raiden-rs/raiden-dynamo/pull/83/files#diff-cbeac8ecc7bb9c2e5969458d5c08fccbR363
