### PR TITLE
support use default #93

### DIFF
--- a/raiden-derive/src/ops/shared.rs
+++ b/raiden-derive/src/ops/shared.rs
@@ -31,69 +31,17 @@ pub(crate) fn expand_attr_to_item(
                 }
               },
             }
-        } else {
-            if use_default {
-                let ty = &f.ty;
-                quote! {
-                  #ident: {
-                    let item = #item_ident.get(#attr_key);
-                    if item.is_none() {
-                        #ty::default()
-                    } else {
-                        let converted = ::raiden::FromAttribute::from_attr(item.cloned());
-                        if converted.is_err() {
-                          // TODO: improve error handling.
-                            return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
-                        }
-                        converted.unwrap()
-                    }
-                  },
-                }
-            } else {
-                quote! {
-                    #ident: {
-                      let item = #item_ident.get(#attr_key);
-                      let converted = ::raiden::FromAttribute::from_attr(item.cloned());
-                      if converted.is_err() {
-                        // TODO: improve error handling.
-                          return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
-                      }
-                      converted.unwrap()
-                    },
-                  }
-            }
-        }
-    }).collect()
-}
-
-/*
-use quote::*;
-
-pub(crate) fn expand_attr_to_item(
-    item_ident: &proc_macro2::Ident,
-    fields: &syn::FieldsNamed,
-    rename_all_type: crate::rename::RenameAllType,
-) -> Vec<proc_macro2::TokenStream> {
-    fields.named.iter().map(|f| {
-        let ident = &f.ident.clone().unwrap();
-        let renamed = crate::finder::find_rename_value(&f.attrs);
-        let use_default = crate::finder::include_unary_attr(&f.attrs, "use_default");
-        let attr_key  = if let Some(renamed) = renamed {
-            renamed
-        }  else if rename_all_type != crate::rename::RenameAllType::None {
-            crate::rename::rename(rename_all_type, ident.to_string())
-        } else {
-            ident.to_string()
-        };
-        if crate::finder::is_option(&f.ty) {
+        } else if use_default {
+            let ty = &f.ty;
             quote! {
               #ident: {
                 let item = #item_ident.get(#attr_key);
                 if item.is_none() {
-                    None
+                    #ty::default()
                 } else {
                     let converted = ::raiden::FromAttribute::from_attr(item.cloned());
                     if converted.is_err() {
+                      // TODO: improve error handling.
                         return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
                     }
                     converted.unwrap()
@@ -101,38 +49,17 @@ pub(crate) fn expand_attr_to_item(
               },
             }
         } else {
-            let field_type = format_ident!("{}", stringify!(&f.ty));
-            if use_default {
-                quote! {
-                    #ident: {
-                        let item = #item_ident.get(#attr_key);
-                        if item.is_none() {
-                            #field_type::default()
-                        } else {
-                            let converted = ::raiden::FromAttribute::from_attr(item.cloned());
-                            if converted.is_err() {
-                                // TODO: improve error handling.
-                                return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
-                            }
-                            converted.unwrap()
-                        }
-                    },
-                }
-            } else {
-              quote! {
-                    #ident: {
-                        let item = #item_ident.get(#attr_key);
-                        let converted = ::raiden::FromAttribute::from_attr(item.cloned());
-                        if converted.is_err() {
-                            // TODO: improve error handling.
-                            return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
-                        }
-                        converted.unwrap()
-                    },
-                }
-            }
+            quote! {
+                #ident: {
+                  let item = #item_ident.get(#attr_key);
+                  let converted = ::raiden::FromAttribute::from_attr(item.cloned());
+                  if converted.is_err() {
+                    // TODO: improve error handling.
+                      return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+                  }
+                  converted.unwrap()
+                },
+              }
         }
     }).collect()
 }
-
-*/

--- a/raiden-derive/src/ops/shared.rs
+++ b/raiden-derive/src/ops/shared.rs
@@ -7,6 +7,7 @@ pub(crate) fn expand_attr_to_item(
 ) -> Vec<proc_macro2::TokenStream> {
     fields.named.iter().map(|f| {
         let ident = &f.ident.clone().unwrap();
+        let use_default = crate::finder::include_unary_attr(&f.attrs, "use_default");
         let renamed = crate::finder::find_rename_value(&f.attrs);
         let attr_key  = if let Some(renamed) = renamed {
             renamed
@@ -31,17 +32,107 @@ pub(crate) fn expand_attr_to_item(
               },
             }
         } else {
-            quote! {
-              #ident: {
-                let item = #item_ident.get(#attr_key);
-                let converted = ::raiden::FromAttribute::from_attr(item.cloned());
-                if converted.is_err() {
-                  // TODO: improve error handling.
-                    return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+            if use_default {
+                let ty = &f.ty;
+                quote! {
+                  #ident: {
+                    let item = #item_ident.get(#attr_key);
+                    if item.is_none() {
+                        #ty::default()
+                    } else {
+                        let converted = ::raiden::FromAttribute::from_attr(item.cloned());
+                        if converted.is_err() {
+                          // TODO: improve error handling.
+                            return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+                        }
+                        converted.unwrap()
+                    }
+                  },
                 }
-                converted.unwrap()
-              },
+            } else {
+                quote! {
+                    #ident: {
+                      let item = #item_ident.get(#attr_key);
+                      let converted = ::raiden::FromAttribute::from_attr(item.cloned());
+                      if converted.is_err() {
+                        // TODO: improve error handling.
+                          return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+                      }
+                      converted.unwrap()
+                    },
+                  }
             }
         }
     }).collect()
 }
+
+/*
+use quote::*;
+
+pub(crate) fn expand_attr_to_item(
+    item_ident: &proc_macro2::Ident,
+    fields: &syn::FieldsNamed,
+    rename_all_type: crate::rename::RenameAllType,
+) -> Vec<proc_macro2::TokenStream> {
+    fields.named.iter().map(|f| {
+        let ident = &f.ident.clone().unwrap();
+        let renamed = crate::finder::find_rename_value(&f.attrs);
+        let use_default = crate::finder::include_unary_attr(&f.attrs, "use_default");
+        let attr_key  = if let Some(renamed) = renamed {
+            renamed
+        }  else if rename_all_type != crate::rename::RenameAllType::None {
+            crate::rename::rename(rename_all_type, ident.to_string())
+        } else {
+            ident.to_string()
+        };
+        if crate::finder::is_option(&f.ty) {
+            quote! {
+              #ident: {
+                let item = #item_ident.get(#attr_key);
+                if item.is_none() {
+                    None
+                } else {
+                    let converted = ::raiden::FromAttribute::from_attr(item.cloned());
+                    if converted.is_err() {
+                        return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+                    }
+                    converted.unwrap()
+                }
+              },
+            }
+        } else {
+            let field_type = format_ident!("{}", stringify!(&f.ty));
+            if use_default {
+                quote! {
+                    #ident: {
+                        let item = #item_ident.get(#attr_key);
+                        if item.is_none() {
+                            #field_type::default()
+                        } else {
+                            let converted = ::raiden::FromAttribute::from_attr(item.cloned());
+                            if converted.is_err() {
+                                // TODO: improve error handling.
+                                return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+                            }
+                            converted.unwrap()
+                        }
+                    },
+                }
+            } else {
+              quote! {
+                    #ident: {
+                        let item = #item_ident.get(#attr_key);
+                        let converted = ::raiden::FromAttribute::from_attr(item.cloned());
+                        if converted.is_err() {
+                            // TODO: improve error handling.
+                            return Err(::raiden::RaidenError::AttributeConvertError{ attr_name: #attr_key.to_string() });
+                        }
+                        converted.unwrap()
+                    },
+                }
+            }
+        }
+    }).collect()
+}
+
+*/

--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -87,7 +87,7 @@ pub trait ToAttrMaps: Sized {
 }
 
 pub trait IntoAttribute: Sized {
-    fn into_attr(self: Self) -> AttributeValue;
+    fn into_attr(self) -> AttributeValue;
 }
 
 pub trait FromAttribute: Sized {
@@ -99,7 +99,7 @@ pub trait FromStringSetItem: Sized {
 }
 
 impl IntoAttribute for String {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         // Empty String is allowed since 2020/5
         // https://aws.amazon.com/jp/about-aws/whats-new/2020/05/amazon-dynamodb-now-supports-empty-values-for-non-key-string-and-binary-attributes-in-dynamodb-tables/
         AttributeValue {
@@ -124,7 +124,7 @@ impl FromAttribute for String {
 }
 
 impl IntoAttribute for &'_ str {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         if self == "" {
             // See. https://github.com/raiden-rs/raiden-dynamo/issues/58
             return AttributeValue {
@@ -140,7 +140,7 @@ impl IntoAttribute for &'_ str {
 }
 
 impl<'a> IntoAttribute for std::borrow::Cow<'a, str> {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         let s = match self {
             std::borrow::Cow::Owned(o) => o,
             std::borrow::Cow::Borrowed(b) => b.to_owned(),
@@ -179,7 +179,7 @@ impl<'a> FromAttribute for std::borrow::Cow<'a, str> {
 macro_rules! default_attr_for_num {
     ($to: ty) => {
         impl IntoAttribute for $to {
-            fn into_attr(self: Self) -> AttributeValue {
+            fn into_attr(self) -> AttributeValue {
                 AttributeValue {
                     n: Some(format!("{}", self)),
                     ..AttributeValue::default()
@@ -214,7 +214,7 @@ default_attr_for_num!(i16);
 default_attr_for_num!(i8);
 
 impl<T: IntoAttribute> IntoAttribute for Option<T> {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         match self {
             Some(value) => value.into_attr(),
             _ => AttributeValue {
@@ -239,7 +239,7 @@ impl<T: FromAttribute> FromAttribute for Option<T> {
 }
 
 impl IntoAttribute for bool {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         AttributeValue {
             bool: Some(self),
             ..AttributeValue::default()
@@ -260,7 +260,7 @@ impl FromAttribute for bool {
 }
 
 impl IntoStringSetItem for String {
-    fn into_ss_item(self: Self) -> String {
+    fn into_ss_item(self) -> String {
         self
     }
 }
@@ -272,7 +272,7 @@ impl FromStringSetItem for String {
 }
 
 impl<A: IntoAttribute> IntoAttribute for Vec<A> {
-    fn into_attr(mut self: Self) -> AttributeValue {
+    fn into_attr(mut self) -> AttributeValue {
         if self.is_empty() {
             // See. https://github.com/raiden-rs/raiden/issues/57
             return AttributeValue {
@@ -307,7 +307,7 @@ impl<A: FromAttribute> FromAttribute for Vec<A> {
 }
 
 impl IntoAttribute for std::collections::HashSet<usize> {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         if self.is_empty() {
             // See. https://github.com/raiden-rs/raiden/issues/57
             //      https://github.com/raiden-rs/raiden-dynamo/issues/64
@@ -340,7 +340,7 @@ impl FromAttribute for std::collections::HashSet<usize> {
 }
 
 impl<A: std::hash::Hash + IntoStringSetItem> IntoAttribute for std::collections::HashSet<A> {
-    fn into_attr(self: Self) -> AttributeValue {
+    fn into_attr(self) -> AttributeValue {
         if self.is_empty() {
             // See. https://github.com/raiden-rs/raiden/issues/57
             //      https://github.com/raiden-rs/raiden-dynamo/issues/64

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -235,7 +235,7 @@ mod tests {
     pub struct CustomSSItem(String);
 
     impl raiden::IntoStringSetItem for CustomSSItem {
-        fn into_ss_item(self: Self) -> String {
+        fn into_ss_item(self) -> String {
             "test".to_owned()
         }
     }

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -467,4 +467,37 @@ mod tests {
         }
         rt.block_on(example());
     }
+
+    #[derive(Raiden)]
+    #[raiden(table_name = "UseDefaultTestData0")]
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UseDefault {
+        #[raiden(partition_key)]
+        id: String,
+        #[raiden(use_default)]
+        is_ok: bool,
+    }
+
+    #[test]
+    fn test_use_default() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = UseDefault::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let res = client.get("id0").run().await;
+            assert_eq!(
+                res.unwrap(),
+                get::GetOutput {
+                    item: UseDefault {
+                        id: "id0".to_owned(),
+                        is_ok: false,
+                    },
+                    consumed_capacity: None,
+                }
+            );
+        }
+        rt.block_on(example());
+    }
 }

--- a/setup/index.js
+++ b/setup/index.js
@@ -482,4 +482,16 @@ const put = (params) =>
     TableName: 'ReservedTestData0',
     Item: { id: { S: 'id0' }, type: { S: 'reserved' } },
   });
+
+  await createTable({
+    TableName: 'UseDefaultTestData0',
+    KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
+    AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  });
+
+  await put({
+    TableName: 'UseDefaultTestData0',
+    Item: { id: { S: 'id0' } },
+  });
 })();


### PR DESCRIPTION
## What does this change?

Support `use_default`. You can use this attribute if you want to assign default value if dynamo item value is none.

``` Rust
    #[derive(Raiden)]
    #[derive(Debug, Clone, PartialEq)]
    pub struct UseDefault {
        #[raiden(partition_key)]
        id: String,
        #[raiden(use_default)]
        is_ok: bool,
    }
```

## References

NA

## Screenshots

NA

## What can I check for bug fixes?

NA
