### PR TITLE
Use is_empty() to resolve clippy errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/raiden/examples/put.rs
+++ b/raiden/examples/put.rs
@@ -19,7 +19,7 @@ impl raiden::IntoAttribute for CustomId {
 }
 
 impl raiden::FromAttribute for CustomId {
-    fn from_attr(value: Option<raiden::AttributeValue>) -> Result<Self, ()> {
+    fn from_attr(value: Option<raiden::AttributeValue>) -> Result<Self, ConversionError> {
         Ok(CustomId(value.unwrap().s.unwrap()))
     }
 }

--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -125,7 +125,7 @@ impl FromAttribute for String {
 
 impl IntoAttribute for &'_ str {
     fn into_attr(self) -> AttributeValue {
-        if self == "" {
+        if self.is_empty() {
             // See. https://github.com/raiden-rs/raiden-dynamo/issues/58
             return AttributeValue {
                 null: Some(true),
@@ -145,7 +145,7 @@ impl<'a> IntoAttribute for std::borrow::Cow<'a, str> {
             std::borrow::Cow::Owned(o) => o,
             std::borrow::Cow::Borrowed(b) => b.to_owned(),
         };
-        if s == "" {
+        if s.is_empty() {
             // See. https://github.com/raiden-rs/raiden-dynamo/issues/58
             return AttributeValue {
                 null: Some(true),

--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -100,7 +100,7 @@ impl std::fmt::Display for ConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConversionError::ValueIsNone => write!(f, "Value is none"),
-            ConversionError::ParseInt => write!(f, "Int parsing error"),
+            ConversionError::ParseInt => write!(f, "Parsing error of integer"),
         }
     }
 }

--- a/raiden/tests/all/get.rs
+++ b/raiden/tests/all/get.rs
@@ -241,7 +241,7 @@ mod tests {
     }
 
     impl raiden::FromStringSetItem for CustomSSItem {
-        fn from_ss_item(value: String) -> Result<Self, ()> {
+        fn from_ss_item(value: String) -> Result<Self, ConversionError> {
             Ok(CustomSSItem(value))
         }
     }

--- a/raiden/tests/all/put.rs
+++ b/raiden/tests/all/put.rs
@@ -287,7 +287,7 @@ mod tests {
     }
 
     impl raiden::FromStringSetItem for Custom {
-        fn from_ss_item(value: String) -> Result<Self, ()> {
+        fn from_ss_item(value: String) -> Result<Self, ConversionError> {
             Ok(Custom {})
         }
     }


### PR DESCRIPTION
## What does this change?

Resolve errors reported by clippy.

## Details

- Use `is_empty()` built-in method
- Define custom error `ConversionError` and use in `FromAttribute` and `FromStringSetItem` trait