### PR TITLE
Support begins with

### DIFF
--- a/raiden-derive/src/key_condition/builder.rs
+++ b/raiden-derive/src/key_condition/builder.rs
@@ -4,7 +4,7 @@ pub fn expand_key_condition_builder(
     attr_enum_name: &proc_macro2::Ident,
     struct_name: &proc_macro2::Ident,
 ) -> proc_macro2::TokenStream {
-    let key_condition_token_name = format_ident!("{}KenConditionToken", struct_name);
+    let key_condition_token_name = format_ident!("{}KeyConditionToken", struct_name);
     quote! {
 
         pub struct #key_condition_token_name;

--- a/raiden-derive/src/ops/query.rs
+++ b/raiden-derive/src/ops/query.rs
@@ -9,7 +9,7 @@ pub(crate) fn expand_query(
     let client_name = format_ident!("{}Client", struct_name);
     let builder_name = format_ident!("{}QueryBuilder", struct_name);
 
-    let key_condition_token_name = format_ident!("{}KenConditionToken", struct_name);
+    let key_condition_token_name = format_ident!("{}KeyConditionToken", struct_name);
 
     let from_item = super::expand_attr_to_item(&format_ident!("res_item"), fields, rename_all_type);
 

--- a/raiden/src/key_condition/mod.rs
+++ b/raiden/src/key_condition/mod.rs
@@ -273,6 +273,7 @@ impl<T> KeyCondition<T> {
         }
     }
 
+    // We can use `begins_with` only with a range key after specifying an EQ condition for the primary key.
     pub fn begins_with(
         self,
         value: impl super::IntoAttribute,

--- a/raiden/tests/all/key_condition.rs
+++ b/raiden/tests/all/key_condition.rs
@@ -43,6 +43,7 @@ mod tests {
                 .eq(1999)
                 .and(User::key_condition(User::num()).eq(100)),
         );
+
         let (key_condition, attribute_names, attribute_values) = cond.build();
         let mut expected_names: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
@@ -78,5 +79,19 @@ mod tests {
         assert_eq!(key_condition, "begins_with(#name, :value0)".to_owned(),);
         assert_eq!(attribute_names, expected_names);
         assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
+    fn test_begins_with_id_and_key_condition() {
+        reset_value_id();
+
+        let cond = User::key_condition(User::id())
+            .eq("id3")
+            .and(User::key_condition(User::year()).begins_with("20"));
+        let (key_condition, _attribute_names, _attribute_values) = cond.build();
+        assert_eq!(
+            key_condition,
+            "#id = :value0 AND (begins_with(#year, :value1))".to_owned(),
+        );
     }
 }

--- a/raiden/tests/all/key_condition.rs
+++ b/raiden/tests/all/key_condition.rs
@@ -62,4 +62,21 @@ mod tests {
         assert_eq!(attribute_names, expected_names);
         assert_eq!(attribute_values, expected_values);
     }
+
+    #[test]
+    fn test_begins_with_key_condition() {
+        reset_value_id();
+
+        let cond = User::key_condition(User::name()).begins_with("bokuweb");
+        let (key_condition, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), "bokuweb".into_attr());
+        assert_eq!(key_condition, "begins_with(#name, :value0)".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
 }

--- a/raiden/tests/all/query.rs
+++ b/raiden/tests/all/query.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_query() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = QueryTestData0::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_query_with_and_key_condition() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = QueryTestData0::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_query_limit_1() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = Test::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_query_limit_5() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = Test::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_query_no_limit() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = Test::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_query_over_limit() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = Test::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_query_over_limit_with_next_token() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = Test::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_query_with_renamed() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = Project::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -247,11 +247,11 @@ mod tests {
         #[raiden(partition_key)]
         id: String,
         name: String,
-        year: usize
+        year: usize,
     }
     #[test]
     fn test_query_for_projection_expression() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         async fn example() {
             let client = QueryTestData0a::client(Region::Custom {
                 endpoint: "http://localhost:8000".into(),
@@ -276,6 +276,51 @@ mod tests {
                             name: "john".to_owned(),
                             year: 2000,
                         },
+                    ],
+                    next_token: None,
+                    scanned_count: Some(2),
+                }
+            )
+        }
+        rt.block_on(example());
+    }
+
+    #[derive(Raiden, Debug, PartialEq)]
+    #[raiden(table_name = "QueryTestData1")]
+    pub struct QueryTestData1 {
+        #[raiden(partition_key)]
+        id: String,
+        #[raiden(sort_key)]
+        name: String,
+    }
+
+    #[test]
+    fn test_query_with_begins_with_key_condition() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        async fn example() {
+            let client = QueryTestData1::client(Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            });
+            let cond = QueryTestData1::key_condition(QueryTestData1::id())
+                .eq("id0")
+                .and(QueryTestData1::key_condition(QueryTestData1::name()).begins_with("j"));
+            let res = client.query().key_condition(cond).run().await;
+
+            assert_eq!(
+                res.unwrap(),
+                query::QueryOutput {
+                    consumed_capacity: None,
+                    count: Some(2),
+                    items: vec![
+                        QueryTestData1 {
+                            id: "id0".to_owned(),
+                            name: "jack".to_owned(),
+                        },
+                        QueryTestData1 {
+                            id: "id0".to_owned(),
+                            name: "john".to_owned(),
+                        }
                     ],
                     next_token: None,
                     scanned_count: Some(2),

--- a/setup/index.js
+++ b/setup/index.js
@@ -96,6 +96,47 @@ const put = (params) =>
     Item: { id: { S: 'id2' }, name: { S: 'alice' }, year: { N: '2013' }, num: { N: '4000' } },
   });
 
+  await put({
+    TableName: 'QueryTestData0',
+    Item: { id: { S: 'id3' }, name: { S: 'bar0' }, year: { N: '1987' }, num: { N: '4000' } },
+  });
+
+  await put({
+    TableName: 'QueryTestData0',
+    Item: { id: { S: 'id3' }, name: { S: 'bar1' }, year: { N: '2000' }, num: { N: '4000' } },
+  });
+
+  await put({
+    TableName: 'QueryTestData0',
+    Item: { id: { S: 'id3' }, name: { S: 'bar2' }, year: { N: '2029' }, num: { N: '4000' } },
+  });
+
+  await createTable({
+    TableName: 'QueryTestData1',
+    KeySchema: [
+      { AttributeName: 'id', KeyType: 'HASH' },
+      { AttributeName: 'name', KeyType: 'RANGE' },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: 'id', AttributeType: 'S' },
+      { AttributeName: 'name', AttributeType: 'S' },
+    ],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  });
+
+  await put({
+    TableName: 'QueryTestData1',
+    Item: { id: { S: 'id0' }, name: { S: 'john' } },
+  });
+  await put({
+    TableName: 'QueryTestData1',
+    Item: { id: { S: 'id0' }, name: { S: 'jack' } },
+  });
+  await put({
+    TableName: 'QueryTestData1',
+    Item: { id: { S: 'id0' }, name: { S: 'bob' } },
+  });
+
   await createTable({
     TableName: 'RenameTestData0',
     KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],


### PR DESCRIPTION
## What does this change?

Support `begins_with` function.

We can use `begins_with` like following if merged.

``` Rust
            let cond = QueryTestData1::key_condition(QueryTestData1::id())
                .eq("id0")
                .and(QueryTestData1::key_condition(QueryTestData1::name()).begins_with("j"));
            let res = client.query().key_condition(cond).run().await;
```

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
