### PR TITLE
Implement display for NextToken

### DIFF
--- a/raiden/src/next_token/mod.rs
+++ b/raiden/src/next_token/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NextToken(String);
 
@@ -8,23 +10,29 @@ impl NextToken {
     pub fn into_attr_values(self) -> Result<super::AttributeValues, super::RaidenError> {
         let decoded = match base64::decode(&self.0) {
             Ok(decoded) => decoded,
-            Err(_) => return Err(super::RaidenError::NextTokenDecodeError)
+            Err(_) => return Err(super::RaidenError::NextTokenDecodeError),
         };
         let s = match std::str::from_utf8(&decoded[..]) {
             Ok(s) => s,
-            Err(_) => return Err(super::RaidenError::NextTokenDecodeError)
+            Err(_) => return Err(super::RaidenError::NextTokenDecodeError),
         };
 
         let deserialized: std::collections::HashMap<String, super::AttributeValue> =
-        match serde_json::from_str(s) {
-            Ok(deserialized) => deserialized,
-            Err(_) => return Err(super::RaidenError::NextTokenDecodeError)
-        };
+            match serde_json::from_str(s) {
+                Ok(deserialized) => deserialized,
+                Err(_) => return Err(super::RaidenError::NextTokenDecodeError),
+            };
         Ok(deserialized)
     }
 
     pub fn from_attr(key: &super::AttributeValues) -> Self {
         let serialized = serde_json::to_string(key).expect("should serialize");
         Self(base64::encode(&serialized))
+    }
+}
+
+impl fmt::Display for NextToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
## What does this change?

NextToken might be needed to convert to String with `.to_string()` in some case, so implements fmt::Display.

## References

None

## Screenshots

none

## What can I check for bug fixes?

This is not a bug fix. 