### PR TITLE
feat: add "or" condition for filter expression

### DIFF
--- a/raiden/src/filter_expression/mod.rs
+++ b/raiden/src/filter_expression/mod.rs
@@ -10,6 +10,11 @@ pub enum FilterExpressionOperator {
         super::AttributeNames,
         super::AttributeValues,
     ),
+    Or(
+        FilterExpressionString,
+        super::AttributeNames,
+        super::AttributeValues,
+    ),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -68,6 +73,15 @@ impl<T> FilterExpressionFilledOrWaitOperator<T> {
             attr: self.attr,
             cond: self.cond,
             operator: FilterExpressionOperator::And(condition_string, attr_names, attr_values),
+            _token: self._token,
+        }
+    }
+    pub fn or(self, cond: impl FilterExpressionBuilder<T>) -> FilterExpressionFilled<T> {
+        let (condition_string, attr_names, attr_values) = cond.build();
+        FilterExpressionFilled {
+            attr: self.attr,
+            cond: self.cond,
+            operator: FilterExpressionOperator::Or(condition_string, attr_names, attr_values),
             _token: self._token,
         }
     }
@@ -157,6 +171,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilled<T> {
     fn build(self) -> (String, super::AttributeNames, super::AttributeValues) {
         let (right_str, right_names, right_values) = match self.operator {
             FilterExpressionOperator::And(s, m, v) => (format!("AND ({})", s), m, v),
+            FilterExpressionOperator::Or(s, m, v) => (format!("OR ({})", s), m, v),
         };
 
         let attr_name = self.attr;

--- a/raiden/tests/all/filter_expression.rs
+++ b/raiden/tests/all/filter_expression.rs
@@ -82,6 +82,36 @@ mod tests {
     }
 
     #[test]
+    fn test_two_or_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name())
+            .eq("bokuweb")
+            .or(User::filter_expression(User::year())
+                .eq(1999)
+                .or(User::filter_expression(User::num()).eq(100)));
+
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        expected_names.insert("#year".to_owned(), "year".to_owned());
+        expected_names.insert("#num".to_owned(), "num".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), "bokuweb".into_attr());
+        expected_values.insert(":value1".to_owned(), 1999.into_attr());
+        expected_values.insert(":value2".to_owned(), 100.into_attr());
+
+        assert_eq!(
+            filter_expression,
+            "#name = :value0 OR (#year = :value1 OR (#num = :value2))".to_owned(),
+        );
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
     fn test_begins_with_filter_expression() {
         reset_value_id();
 


### PR DESCRIPTION
## What does this change?

Implement "or" condition for the filter expression

## References

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax
