### PR TITLE
Add operators for filter expression

### DIFF
--- a/raiden/src/filter_expression/mod.rs
+++ b/raiden/src/filter_expression/mod.rs
@@ -10,6 +10,11 @@ pub enum FilterExpressionOperator {
         super::AttributeNames,
         super::AttributeValues,
     ),
+    Or(
+        FilterExpressionString,
+        super::AttributeNames,
+        super::AttributeValues,
+    ),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -68,6 +73,15 @@ impl<T> FilterExpressionFilledOrWaitOperator<T> {
             attr: self.attr,
             cond: self.cond,
             operator: FilterExpressionOperator::And(condition_string, attr_names, attr_values),
+            _token: self._token,
+        }
+    }
+    pub fn or(self, cond: impl FilterExpressionBuilder<T>) -> FilterExpressionFilled<T> {
+        let (condition_string, attr_names, attr_values) = cond.build();
+        FilterExpressionFilled {
+            attr: self.attr,
+            cond: self.cond,
+            operator: FilterExpressionOperator::Or(condition_string, attr_names, attr_values),
             _token: self._token,
         }
     }
@@ -157,6 +171,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilled<T> {
     fn build(self) -> (String, super::AttributeNames, super::AttributeValues) {
         let (right_str, right_names, right_values) = match self.operator {
             FilterExpressionOperator::And(s, m, v) => (format!("AND ({})", s), m, v),
+            FilterExpressionOperator::Or(s, m, v) => (format!("OR ({})", s), m, v),
         };
 
         let attr_name = self.attr;

--- a/raiden/src/filter_expression/mod.rs
+++ b/raiden/src/filter_expression/mod.rs
@@ -39,7 +39,6 @@ pub enum FilterExpressionTypes {
     AttributeNotExists(),
     AttributeType(super::Placeholder, super::AttributeType),
     Contains(super::Placeholder, super::AttributeValue),
-    Size(),
 }
 
 pub trait FilterExpressionBuilder<T> {
@@ -196,9 +195,6 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
                     attr_values,
                 )
             }
-            FilterExpressionTypes::Size() => {
-                (format!("size(#{})", attr_name), attr_names, attr_values)
-            }
         }
     }
 }
@@ -265,9 +261,6 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilled<T> {
             FilterExpressionTypes::Contains(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
                 format!("contains(#{}, {})", attr_name, placeholder)
-            }
-            FilterExpressionTypes::Size() => {
-                format!("size(#{})", attr_name)
             }
         };
         (
@@ -409,15 +402,6 @@ impl<T> FilterExpression<T> {
     ) -> FilterExpressionFilledOrWaitOperator<T> {
         let placeholder = format!(":value{}", super::generate_value_id());
         let cond = FilterExpressionTypes::Contains(placeholder, value.into_attr());
-        FilterExpressionFilledOrWaitOperator {
-            attr: self.attr,
-            cond,
-            _token: std::marker::PhantomData,
-        }
-    }
-
-    pub fn size(self) -> FilterExpressionFilledOrWaitOperator<T> {
-        let cond = FilterExpressionTypes::Size();
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
             cond,

--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -57,6 +57,15 @@ pub enum AttributeType {
     M,    // Map
 }
 
+impl IntoAttribute for AttributeType {
+    fn into_attr(self) -> AttributeValue {
+        AttributeValue {
+            s: Some(self.to_string()),
+            ..AttributeValue::default()
+        }
+    }
+}
+
 impl std::fmt::Display for AttributeType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)

--- a/raiden/tests/all/filter_expression.rs
+++ b/raiden/tests/all/filter_expression.rs
@@ -141,4 +141,89 @@ mod tests {
             "#id <> :value0 AND (begins_with(#year, :value1))".to_owned(),
         );
     }
+
+    #[test]
+    fn test_attribute_exists_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name()).attribute_exists();
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        assert_eq!(filter_expression, "attribute_exists(#name)".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
+    fn test_attribute_not_exists_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name()).attribute_not_exists();
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        assert_eq!(filter_expression, "attribute_not_exists(#name)".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
+    fn test_attribute_type_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name()).attribute_type(raiden::AttributeType::S);
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), "S".into_attr());
+        assert_eq!(
+            filter_expression,
+            "attribute_type(#name, :value0)".to_owned(),
+        );
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
+    fn test_contains_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name()).contains("boku");
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), "boku".into_attr());
+        assert_eq!(filter_expression, "contains(#name, :value0)".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
+    fn test_size_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name()).size();
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        assert_eq!(filter_expression, "size(#name)".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
 }

--- a/raiden/tests/all/filter_expression.rs
+++ b/raiden/tests/all/filter_expression.rs
@@ -210,20 +210,4 @@ mod tests {
         assert_eq!(attribute_names, expected_names);
         assert_eq!(attribute_values, expected_values);
     }
-
-    #[test]
-    fn test_size_filter_expression() {
-        reset_value_id();
-
-        let cond = User::filter_expression(User::name()).size();
-        let (filter_expression, attribute_names, attribute_values) = cond.build();
-        let mut expected_names: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
-        expected_names.insert("#name".to_owned(), "name".to_owned());
-        let expected_values: std::collections::HashMap<String, AttributeValue> =
-            std::collections::HashMap::new();
-        assert_eq!(filter_expression, "size(#name)".to_owned(),);
-        assert_eq!(attribute_names, expected_names);
-        assert_eq!(attribute_values, expected_values);
-    }
 }

--- a/raiden/tests/all/filter_expression.rs
+++ b/raiden/tests/all/filter_expression.rs
@@ -82,6 +82,36 @@ mod tests {
     }
 
     #[test]
+    fn test_two_or_filter_expression() {
+        reset_value_id();
+
+        let cond = User::filter_expression(User::name())
+            .eq("bokuweb")
+            .or(User::filter_expression(User::year())
+                .eq(1999)
+                .or(User::filter_expression(User::num()).eq(100)));
+
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        expected_names.insert("#year".to_owned(), "year".to_owned());
+        expected_names.insert("#num".to_owned(), "num".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), "bokuweb".into_attr());
+        expected_values.insert(":value1".to_owned(), 1999.into_attr());
+        expected_values.insert(":value2".to_owned(), 100.into_attr());
+
+        assert_eq!(
+            filter_expression,
+            "#name = :value0 OR (#year = :value1 OR (#num = :value2))".to_owned(),
+        );
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
     fn test_begins_with_filter_expression() {
         reset_value_id();
 

--- a/raiden/tests/all/scan.rs
+++ b/raiden/tests/all/scan.rs
@@ -201,6 +201,7 @@ mod tests {
         name: String,
         year: usize,
         num: usize,
+        option: Option<String>,
     }
 
     #[tokio::test]
@@ -210,6 +211,53 @@ mod tests {
             name: "ap-northeast-1".into(),
         });
         let filter = Scan::filter_expression(Scan::num()).eq(1000);
+        let res = client.scan().filter(filter).run().await.unwrap();
+        assert_eq!(res.items.len(), 50);
+    }
+
+    #[tokio::test]
+    async fn test_or_with_contain_filter() {
+        let client = Scan::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let filter = Scan::filter_expression(Scan::num())
+            .eq(1000)
+            .or(Scan::filter_expression(Scan::id()).contains("scanId50"));
+        let res = client.scan().filter(filter).run().await.unwrap();
+        assert_eq!(res.items.len(), 51);
+    }
+
+    #[tokio::test]
+    async fn test_attribute_exists_filter() {
+        let client = Scan::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let filter = Scan::filter_expression(Scan::option()).attribute_exists();
+        let res = client.scan().filter(filter).run().await.unwrap();
+        assert_eq!(res.items.len(), 50);
+    }
+
+    #[tokio::test]
+    async fn test_attribute_not_exists_filter() {
+        let client = Scan::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let filter = Scan::filter_expression(Scan::option()).attribute_not_exists();
+        let res = client.scan().filter(filter).run().await.unwrap();
+        assert_eq!(res.items.len(), 50);
+    }
+
+    #[tokio::test]
+    async fn test_attribute_type_filter() {
+        let client = Scan::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let filter =
+            Scan::filter_expression(Scan::option()).attribute_type(raiden::AttributeType::S);
         let res = client.scan().filter(filter).run().await.unwrap();
         assert_eq!(res.items.len(), 50);
     }

--- a/setup/fixtures/query_test_data_0.ts
+++ b/setup/fixtures/query_test_data_0.ts
@@ -56,5 +56,25 @@ export const queryTestData0: CreateAndPut = {
       year: { N: "2029" },
       num: { N: "4000" },
     },
+    {
+      id: { S: "id4" },
+      name: { S: "bar0" },
+      year: { N: "2029" },
+      num: { N: "4000" },
+    },
+    {
+      id: { S: "id4" },
+      name: { S: "bar1" },
+      year: { N: "2000" },
+      num: { N: "4000" },
+      option: { S: "option2" },
+    },
+    {
+      id: { S: "id4" },
+      name: { S: "bob" },
+      year: { N: "1999" },
+      num: { N: "4000" },
+      option: { S: "option2" },
+    },
   ],
 };

--- a/setup/fixtures/scan_with_filter_test_data_0.ts
+++ b/setup/fixtures/scan_with_filter_test_data_0.ts
@@ -19,6 +19,7 @@ export const scanWithFilterTestData0: CreateAndPut = {
       name: { S: "scanAlice${i}" },
       year: { N: "2001" },
       num: { N: i % 2 ? "1000" : "2000" },
+      option: i % 2 ? { S: "option${i}" } : null,
     };
   }),
 };


### PR DESCRIPTION
## What does this change?

This PR is for adding the following operators to the filter expression.
- `OR` expression
- `attribute_exists` function
- `attribute_not_exists` function
- `attribute_type` function
- `contains` function

## References

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax
