### PR TITLE
add not function for filter expression

### DIFF
--- a/raiden-derive/src/filter_expression/builder.rs
+++ b/raiden-derive/src/filter_expression/builder.rs
@@ -17,6 +17,15 @@ pub fn expand_filter_expression_builder(
                     _token: std::marker::PhantomData,
                 }
             }
+            pub fn filter_expression_with_not(builder: impl ::raiden::FilterExpressionBuilder<#filter_expression_token_name>) -> ::raiden::FilterExpressionNotWrapper<#filter_expression_token_name> {
+                let (str, names, values) = builder.build();
+                ::raiden::FilterExpressionNotWrapper{
+                    condition_string: str,
+                    attr_names: names,
+                    attr_values: values,
+                    _token: std::marker::PhantomData,
+                }
+            }
         }
     }
 }

--- a/raiden/src/filter_expression/mod.rs
+++ b/raiden/src/filter_expression/mod.rs
@@ -58,6 +58,14 @@ pub struct FilterExpression<T> {
 }
 
 #[derive(Debug, Clone)]
+pub struct FilterExpressionNotWrapper<T> {
+    pub condition_string: String,
+    pub attr_names: std::collections::HashMap<String, String>,
+    pub attr_values: std::collections::HashMap<String, rusoto_dynamodb_default::AttributeValue>,
+    pub _token: std::marker::PhantomData<fn() -> T>,
+}
+
+#[derive(Debug, Clone)]
 pub struct FilterExpressionFilledOrWaitOperator<T> {
     attr: String,
     cond: FilterExpressionTypes,
@@ -90,6 +98,16 @@ impl<T> FilterExpressionFilledOrWaitOperator<T> {
             operator: FilterExpressionOperator::Or(condition_string, attr_names, attr_values),
             _token: self._token,
         }
+    }
+}
+
+impl<T> FilterExpressionBuilder<T> for FilterExpressionNotWrapper<T> {
+    fn build(self) -> (String, super::AttributeNames, super::AttributeValues) {
+        (
+            format!("NOT ({})", self.condition_string),
+            self.attr_names,
+            self.attr_values,
+        )
     }
 }
 

--- a/raiden/tests/all/filter_expression.rs
+++ b/raiden/tests/all/filter_expression.rs
@@ -210,4 +210,21 @@ mod tests {
         assert_eq!(attribute_names, expected_names);
         assert_eq!(attribute_values, expected_values);
     }
+
+    #[test]
+    fn test_not_function_filter_expression() {
+        reset_value_id();
+        let cond =
+            User::filter_expression_with_not(User::filter_expression(User::name()).eq("notMatch"));
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), "notMatch".into_attr());
+        assert_eq!(filter_expression, "NOT (#name = :value0)".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
 }

--- a/raiden/tests/all/query.rs
+++ b/raiden/tests/all/query.rs
@@ -107,6 +107,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_query_with_not_function_filter() {
+        let client = QueryTestData0::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let cond = QueryTestData0::key_condition(QueryTestData0::id()).eq("id3");
+        let filter = QueryTestData0::filter_expression_with_not(
+            QueryTestData0::filter_expression(QueryTestData0::name()).eq("bar1"),
+        );
+        let res = client
+            .query()
+            .key_condition(cond)
+            .filter(filter)
+            .run()
+            .await
+            .unwrap();
+        assert_eq!(res.items.len(), 2);
+    }
+
+    #[tokio::test]
     async fn test_query_with_or_filter() {
         let client = QueryTestData0::client(Region::Custom {
             endpoint: "http://localhost:8000".into(),

--- a/raiden/tests/all/scan.rs
+++ b/raiden/tests/all/scan.rs
@@ -216,6 +216,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_not_function_filter() {
+        let client = Scan::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let filter =
+            Scan::filter_expression_with_not(Scan::filter_expression(Scan::num()).eq(1000));
+        let res = client.scan().filter(filter).run().await.unwrap();
+        assert_eq!(res.items.len(), 50);
+    }
+
+    #[tokio::test]
     async fn test_or_with_contain_filter() {
         let client = Scan::client(Region::Custom {
             endpoint: "http://localhost:8000".into(),


### PR DESCRIPTION
## What does this change?

This PR is to add "NOT" function for the filter expression.

## References

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax
