### PR TITLE
add size function for filter expression

### DIFF
--- a/raiden-derive/src/filter_expression/builder.rs
+++ b/raiden-derive/src/filter_expression/builder.rs
@@ -14,6 +14,7 @@ pub fn expand_filter_expression_builder(
                 let attr = attr.into_attr_name();
                 ::raiden::FilterExpression {
                     attr,
+                    size_attr: false,
                     _token: std::marker::PhantomData,
                 }
             }

--- a/raiden/src/filter_expression/mod.rs
+++ b/raiden/src/filter_expression/mod.rs
@@ -54,12 +54,14 @@ pub trait FilterExpressionBuilder<T> {
 #[derive(Debug, Clone)]
 pub struct FilterExpression<T> {
     pub attr: String,
+    pub size_attr: bool,
     pub _token: std::marker::PhantomData<fn() -> T>,
 }
 
 #[derive(Debug, Clone)]
 pub struct FilterExpressionFilledOrWaitOperator<T> {
     attr: String,
+    size_attr: bool,
     cond: FilterExpressionTypes,
     _token: std::marker::PhantomData<fn() -> T>,
 }
@@ -67,6 +69,7 @@ pub struct FilterExpressionFilledOrWaitOperator<T> {
 #[derive(Debug, Clone)]
 pub struct FilterExpressionFilled<T> {
     attr: String,
+    size_attr: bool,
     cond: FilterExpressionTypes,
     operator: FilterExpressionOperator,
     _token: std::marker::PhantomData<fn() -> T>,
@@ -77,6 +80,7 @@ impl<T> FilterExpressionFilledOrWaitOperator<T> {
         let (condition_string, attr_names, attr_values) = cond.build();
         FilterExpressionFilled {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond: self.cond,
             operator: FilterExpressionOperator::And(condition_string, attr_names, attr_values),
             _token: self._token,
@@ -86,6 +90,7 @@ impl<T> FilterExpressionFilledOrWaitOperator<T> {
         let (condition_string, attr_names, attr_values) = cond.build();
         FilterExpressionFilled {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond: self.cond,
             operator: FilterExpressionOperator::Or(condition_string, attr_names, attr_values),
             _token: self._token,
@@ -100,11 +105,16 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
         let mut attr_values: super::AttributeValues = std::collections::HashMap::new();
 
         attr_names.insert(format!("#{}", attr_name), attr_name.clone());
+        let left_cond = if self.size_attr {
+            format!("size(#{})", attr_name)
+        } else {
+            format!("#{}", attr_name)
+        };
         match self.cond {
             FilterExpressionTypes::Eq(placeholder, value) => {
                 attr_values.insert(placeholder.to_string(), value);
                 (
-                    format!("#{} = {}", attr_name, placeholder),
+                    format!("{} = {}", left_cond, placeholder),
                     attr_names,
                     attr_values,
                 )
@@ -112,7 +122,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
             FilterExpressionTypes::Not(placeholder, value) => {
                 attr_values.insert(placeholder.to_string(), value);
                 (
-                    format!("#{} <> {}", attr_name, placeholder),
+                    format!("{} <> {}", left_cond, placeholder),
                     attr_names,
                     attr_values,
                 )
@@ -120,7 +130,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
             FilterExpressionTypes::Gt(placeholder, value) => {
                 attr_values.insert(placeholder.to_string(), value);
                 (
-                    format!("#{} > {}", attr_name, placeholder),
+                    format!("{} > {}", left_cond, placeholder),
                     attr_names,
                     attr_values,
                 )
@@ -128,7 +138,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
             FilterExpressionTypes::Ge(placeholder, value) => {
                 attr_values.insert(placeholder.to_string(), value);
                 (
-                    format!("#{} >= {}", attr_name, placeholder),
+                    format!("{} >= {}", left_cond, placeholder),
                     attr_names,
                     attr_values,
                 )
@@ -136,7 +146,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
             FilterExpressionTypes::Le(placeholder, value) => {
                 attr_values.insert(placeholder.to_string(), value);
                 (
-                    format!("#{} <= {}", attr_name, placeholder),
+                    format!("{} <= {}", left_cond, placeholder),
                     attr_names,
                     attr_values,
                 )
@@ -144,7 +154,7 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
             FilterExpressionTypes::Lt(placeholder, value) => {
                 attr_values.insert(placeholder.to_string(), value);
                 (
-                    format!("#{} < {}", attr_name, placeholder),
+                    format!("{} < {}", left_cond, placeholder),
                     attr_names,
                     attr_values,
                 )
@@ -154,8 +164,8 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilledOrWaitOperator<T> {
                 attr_values.insert(placeholder2.to_string(), value2);
                 (
                     format!(
-                        "#{} BETWEEN {} AND {}",
-                        attr_name, placeholder1, placeholder2
+                        "{} BETWEEN {} AND {}",
+                        left_cond, placeholder1, placeholder2
                     ),
                     attr_names,
                     attr_values,
@@ -210,38 +220,43 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilled<T> {
         let mut left_names: super::AttributeNames = std::collections::HashMap::new();
         let mut left_values: super::AttributeValues = std::collections::HashMap::new();
         left_names.insert(format!("#{}", attr_name), attr_name.clone());
+        let left_cond = if self.size_attr {
+            format!("size(#{})", attr_name)
+        } else {
+            format!("#{}", attr_name)
+        };
 
         let left_str = match self.cond {
             FilterExpressionTypes::Eq(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
-                format!("#{} = {}", attr_name, placeholder)
+                format!("{} = {}", left_cond, placeholder)
             }
             FilterExpressionTypes::Not(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
-                format!("#{} <> {}", attr_name, placeholder)
+                format!("{} <> {}", left_cond, placeholder)
             }
             FilterExpressionTypes::Gt(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
-                format!("#{} > {}", attr_name, placeholder)
+                format!("{} > {}", left_cond, placeholder)
             }
             FilterExpressionTypes::Ge(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
-                format!("#{} >= {}", attr_name, placeholder)
+                format!("{} >= {}", left_cond, placeholder)
             }
             FilterExpressionTypes::Le(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
-                format!("#{} <= {}", attr_name, placeholder)
+                format!("{} <= {}", left_cond, placeholder)
             }
             FilterExpressionTypes::Lt(placeholder, value) => {
                 left_values.insert(placeholder.clone(), value);
-                format!("#{} < {}", attr_name, placeholder)
+                format!("{} < {}", left_cond, placeholder)
             }
             FilterExpressionTypes::Between(placeholder1, value1, placeholder2, value2) => {
                 left_values.insert(placeholder1.clone(), value1);
                 left_values.insert(placeholder2.clone(), value2);
                 format!(
-                    "#{} BETWEEN {} AND {}",
-                    attr_name, placeholder1, placeholder2
+                    "{} BETWEEN {} AND {}",
+                    left_cond, placeholder1, placeholder2
                 )
             }
             FilterExpressionTypes::BeginsWith(placeholder, value) => {
@@ -272,11 +287,17 @@ impl<T> FilterExpressionBuilder<T> for FilterExpressionFilled<T> {
 }
 
 impl<T> FilterExpression<T> {
+    pub fn size(mut self) -> Self {
+        self.size_attr = true;
+        self
+    }
+
     pub fn eq(self, value: impl super::IntoAttribute) -> FilterExpressionFilledOrWaitOperator<T> {
         let placeholder = format!(":value{}", super::generate_value_id());
         let cond = FilterExpressionTypes::Eq(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -287,6 +308,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::Not(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -297,6 +319,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::Gt(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -306,6 +329,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::Ge(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -316,6 +340,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::Le(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -326,6 +351,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::Lt(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -346,6 +372,7 @@ impl<T> FilterExpression<T> {
         );
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -360,6 +387,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::BeginsWith(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -369,6 +397,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::AttributeExists();
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -378,6 +407,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::AttributeNotExists();
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -391,6 +421,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::AttributeType(placeholder, attribute_type);
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }
@@ -404,6 +435,7 @@ impl<T> FilterExpression<T> {
         let cond = FilterExpressionTypes::Contains(placeholder, value.into_attr());
         FilterExpressionFilledOrWaitOperator {
             attr: self.attr,
+            size_attr: self.size_attr,
             cond,
             _token: std::marker::PhantomData,
         }

--- a/raiden/tests/all/filter_expression.rs
+++ b/raiden/tests/all/filter_expression.rs
@@ -35,6 +35,22 @@ mod tests {
     }
 
     #[test]
+    fn test_size_filter_expression() {
+        reset_value_id();
+        let cond = User::filter_expression(User::name()).size().eq(7);
+        let (filter_expression, attribute_names, attribute_values) = cond.build();
+        let mut expected_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        expected_names.insert("#name".to_owned(), "name".to_owned());
+        let mut expected_values: std::collections::HashMap<String, AttributeValue> =
+            std::collections::HashMap::new();
+        expected_values.insert(":value0".to_owned(), 7.into_attr());
+        assert_eq!(filter_expression, "size(#name) = :value0".to_owned(),);
+        assert_eq!(attribute_names, expected_names);
+        assert_eq!(attribute_values, expected_values);
+    }
+
+    #[test]
     fn test_not_filter_expression() {
         reset_value_id();
         let cond = User::filter_expression(User::name()).not("raiden");

--- a/raiden/tests/all/query.rs
+++ b/raiden/tests/all/query.rs
@@ -107,6 +107,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_query_with_size_filter() {
+        let client = QueryTestData0::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let cond = QueryTestData0::key_condition(QueryTestData0::id()).eq("id5");
+        let filter = QueryTestData0::filter_expression(QueryTestData0::name())
+            .size()
+            .ge(4);
+        let res = client
+            .query()
+            .key_condition(cond)
+            .filter(filter)
+            .run()
+            .await
+            .unwrap();
+        assert_eq!(res.items.len(), 2);
+    }
+
+    #[tokio::test]
     async fn test_query_with_or_filter() {
         let client = QueryTestData0::client(Region::Custom {
             endpoint: "http://localhost:8000".into(),

--- a/raiden/tests/all/scan.rs
+++ b/raiden/tests/all/scan.rs
@@ -216,6 +216,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_size_filter() {
+        let client = Scan::client(Region::Custom {
+            endpoint: "http://localhost:8000".into(),
+            name: "ap-northeast-1".into(),
+        });
+        let filter = Scan::filter_expression(Scan::name()).size().eq(10);
+        let res = client.scan().filter(filter).run().await.unwrap();
+        assert_eq!(res.items.len(), 10);
+    }
+
+    #[tokio::test]
     async fn test_or_with_contain_filter() {
         let client = Scan::client(Region::Custom {
             endpoint: "http://localhost:8000".into(),

--- a/setup/fixtures/query_test_data_0.ts
+++ b/setup/fixtures/query_test_data_0.ts
@@ -76,5 +76,26 @@ export const queryTestData0: CreateAndPut = {
       num: { N: "4000" },
       option: { S: "option2" },
     },
+    {
+      id: { S: "id5" },
+      name: { S: "bob" },
+      year: { N: "1999" },
+      num: { N: "4000" },
+      option: { S: "option2" },
+    },
+    {
+      id: { S: "id5" },
+      name: { S: "bob0" },
+      year: { N: "2000" },
+      num: { N: "4000" },
+      option: { S: "option2" },
+    },
+    {
+      id: { S: "id5" },
+      name: { S: "bob1" },
+      year: { N: "3000" },
+      num: { N: "4000" },
+      option: { S: "option2" },
+    },
   ],
 };

--- a/setup/fixtures/scan_with_filter_test_data_0.ts
+++ b/setup/fixtures/scan_with_filter_test_data_0.ts
@@ -16,10 +16,10 @@ export const scanWithFilterTestData0: CreateAndPut = {
   items: [...new Array(100)].map((_, i) => {
     return {
       id: { S: `scanId${i}` },
-      name: { S: "scanAlice${i}" },
+      name: { S: `scanAlice${i}` },
       year: { N: "2001" },
       num: { N: i % 2 ? "1000" : "2000" },
-      option: i % 2 ? { S: "option${i}" } : null,
+      option: i % 2 ? { S: `option${i}` } : null,
     };
   }),
 };


### PR DESCRIPTION
## What does this change?

This PR is to add size function for the filter expression.

## References

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax
