### PR TITLE
add client_with to struct

### DIFF
--- a/raiden-derive/src/lib.rs
+++ b/raiden-derive/src/lib.rs
@@ -180,8 +180,18 @@ pub fn derive_raiden(input: TokenStream) -> TokenStream {
         #transact_write
 
         impl #client_name {
+
             pub fn new(region: ::raiden::Region) -> Self {
                 let client = ::raiden::DynamoDbClient::new(region);
+                Self::new_with_dynamo_db_client(client)
+            }
+
+            pub fn new_with_client(client: ::raiden::Client, region: ::raiden::Region) -> Self {
+                let client = ::raiden::DynamoDbClient::new_with_client(client, region);
+                Self::new_with_dynamo_db_client(client)
+            }
+
+            fn new_with_dynamo_db_client(client: ::raiden::DynamoDbClient) -> Self {
                 let names = {
                     let mut names: ::raiden::AttributeNames = std::collections::HashMap::new();
                     #(#insertion_attribute_name)*
@@ -223,6 +233,9 @@ pub fn derive_raiden(input: TokenStream) -> TokenStream {
         impl #struct_name {
             pub fn client(region: ::raiden::Region) -> #client_name {
                 #client_name::new(region)
+            }
+            pub fn client_with(client: ::raiden::Client, region: ::raiden::Region) -> #client_name {
+                #client_name::new_with_client(client, region)
             }
         }
 

--- a/raiden/examples/with_http_client.rs
+++ b/raiden/examples/with_http_client.rs
@@ -1,0 +1,36 @@
+use raiden::*;
+
+#[derive(Raiden)]
+#[raiden(table_name = "user")]
+pub struct User {
+    #[raiden(partition_key)]
+    pub id: String,
+    #[raiden(sort_key)]
+    pub year: usize,
+    #[raiden(uuid)]
+    pub uuid: String,
+    pub name: String,
+}
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    async fn example() {
+        let dispatcher =
+            raiden::request::HttpClient::new().expect("failed to create request dispatcher");
+        let credentials_provider = raiden::credential::DefaultCredentialsProvider::new()
+            .expect("failed to create credentials provider");
+        let core_client = raiden::Client::new_with(credentials_provider, dispatcher);
+
+        let client = User::client_with(
+            core_client,
+            Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            },
+        );
+
+        let keys: Vec<(&str, usize)> = vec![("bokuweb", 2019), ("raiden", 2020)];
+        let _ = client.batch_get(keys).run().await;
+    }
+    rt.block_on(example());
+}


### PR DESCRIPTION
## What does this change?

added `client_with` to raiden struct to use `rusoto::Client`.
this allows to select CredentialProviders like below.
https://github.com/raiden-rs/raiden-dynamo/blob/014328e400948f54987ad0f91a1046ed23313713/raiden/examples/with_http_client.rs#L19-L30

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
