### PR TITLE
Add new_with_client to WriteTx

### DIFF
--- a/raiden/examples/transact_write_with_http_client.rs
+++ b/raiden/examples/transact_write_with_http_client.rs
@@ -1,0 +1,43 @@
+use raiden::*;
+
+#[derive(Raiden)]
+#[raiden(table_name = "user")]
+pub struct User {
+    #[raiden(partition_key)]
+    pub id: String,
+    pub name: String,
+}
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    async fn example() {
+        let dispatcher =
+            raiden::request::HttpClient::new().expect("failed to create request dispatcher");
+        let credentials_provider = raiden::credential::DefaultCredentialsProvider::new()
+            .expect("failed to create credentials provider");
+        let core_client = raiden::Client::new_with(credentials_provider, dispatcher);
+
+        let tx = ::raiden::WriteTx::new_with_client(
+            core_client,
+            Region::Custom {
+                endpoint: "http://localhost:8000".into(),
+                name: "ap-northeast-1".into(),
+            },
+        );
+        let cond = User::condition().attr_not_exists(User::id());
+        let input = User::put_item_builder()
+            .id("testId".to_owned())
+            .name("bokuweb".to_owned())
+            .build();
+        let input2 = User::put_item_builder()
+            .id("testId2".to_owned())
+            .name("bokuweb".to_owned())
+            .build();
+        tx.put(User::put(input).condition(cond))
+            .put(User::put(input2))
+            .run()
+            .await
+            .unwrap();
+    }
+    rt.block_on(example());
+}

--- a/raiden/src/ops/transact_write.rs
+++ b/raiden/src/ops/transact_write.rs
@@ -14,6 +14,14 @@ impl WriteTx {
             retry_condition: crate::RetryCondition::new(),
         }
     }
+    pub fn new_with_client(client: crate::Client, region: crate::Region) -> Self {
+        let client = crate::DynamoDbClient::new_with_client(client, region);
+        Self {
+            items: vec![],
+            client,
+            retry_condition: crate::RetryCondition::new(),
+        }
+    }
 
     pub fn with_retries(mut self, s: Box<dyn crate::retry::RetryStrategy + Send + Sync>) -> Self {
         self.retry_condition.strategy = s;


### PR DESCRIPTION
## What does this change?

added `new_with_client` to `WriteTx` struct to use rusoto::Client.
this allows to select CredentialProviders like below.
https://github.com/yuntara/raiden-dynamo/blob/6669b22241c6ba18d3a84152cf51a96304070cf2/raiden/examples/transact_write_with_http_client.rs#L14-L26
## References

https://github.com/raiden-rs/raiden-dynamo/pull/202

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
