### PR TITLE
chore: enable to retry in all operations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
           deno-version: v1.x
       - name: Run deno fmt and deno lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -655,6 +655,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -859,7 +870,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1047,7 +1058,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1432,14 +1443,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1510,6 +1521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1582,7 +1603,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1593,7 +1614,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1639,19 +1660,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1662,7 +1685,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1724,7 +1747,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1805,11 +1828,13 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1882,7 +1907,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -1917,7 +1942,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2009,7 +2034,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2020,7 +2045,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2167,7 +2192,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/raiden-derive/Cargo.toml
+++ b/raiden-derive/Cargo.toml
@@ -16,7 +16,7 @@ convert_case = "^0.8.0"
 ident_case = "^1.0.1"
 proc-macro2 = "^1.0.95"
 quote = "^1.0.40"
-syn = "^2.0.101"
+syn = "^2.0.104"
 
 [features]
 default = []

--- a/raiden-derive/src/ops/delete.rs
+++ b/raiden-derive/src/ops/delete.rs
@@ -33,6 +33,8 @@ pub(crate) fn expand_delete_item(
                     #builder_name {
                         client: &self.client,
                         input,
+                        policy: self.retry_condition.strategy.policy(),
+                        condition: &self.retry_condition,
                     }
                 }
             }
@@ -54,6 +56,8 @@ pub(crate) fn expand_delete_item(
                     #builder_name {
                         client: &self.client,
                         input,
+                        policy: self.retry_condition.strategy.policy(),
+                        condition: &self.retry_condition,
                     }
                 }
             }
@@ -63,12 +67,12 @@ pub(crate) fn expand_delete_item(
     let api_call_token = super::api_call_token!("delete_item");
     let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
         (
-            quote! { #builder_name::inner_run(&self.input.table_name.clone(), &self.client, self.input).await? },
-            quote! { table_name: &str, },
+            quote! { #builder_name::inner_run(input.table_name.clone(), client, input).await },
+            quote! { table_name: String, },
         )
     } else {
         (
-            quote! { #builder_name::inner_run(&self.client, self.input).await? },
+            quote! { #builder_name::inner_run(client, input).await },
             quote! {},
         )
     };
@@ -79,6 +83,8 @@ pub(crate) fn expand_delete_item(
         pub struct #builder_name<'a> {
             pub client: &'a ::raiden::DynamoDbClient,
             pub input: ::raiden::DeleteItemInput,
+            pub policy: ::raiden::Policy,
+            pub condition: &'a ::raiden::retry::RetryCondition,
         }
 
         impl<'a> #builder_name<'a> {
@@ -100,13 +106,18 @@ pub(crate) fn expand_delete_item(
             }
 
             pub async fn run(self) -> Result<(), ::raiden::RaidenError> {
-                #call_inner_run;
-                Ok(())
+                let Self { client, input, policy, condition } = self;
+                let policy: ::raiden::RetryPolicy = policy.into();
+                policy.retry_if(move || {
+                    let client = client.clone();
+                    let input = input.clone();
+                    async { #call_inner_run }
+                }, condition).await
             }
 
             async fn inner_run(
                 #inner_run_args
-                client: &::raiden::DynamoDbClient,
+                client: ::raiden::DynamoDbClient,
                 input: ::raiden::DeleteItemInput,
             ) -> Result<(), ::raiden::RaidenError> {
                 #api_call_token?;

--- a/raiden/Cargo.toml
+++ b/raiden/Cargo.toml
@@ -28,16 +28,16 @@ rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.48.0", defa
 safe-builder = { tag = "0.0.6", git = "https://github.com/raiden-rs/safe-builder.git" }
 serde = { version = "^1.0.219", features = ["derive"] }
 serde_derive = "^1.0.219"
-serde_json = "^1.0.140"
+serde_json = "^1.0.142"
 thiserror = "^2.0.12"
 tracing = { version = "^0.1.41", optional = true }
-uuid = { version = "^1.16.0", features = ["v4"] }
+uuid = { version = "^1.17.0", features = ["v4"] }
 
 [dev-dependencies]
 pretty_assertions = "^1.4.1"
 raiden = { path = "./", features = ["tracing"], default-features = false }
 time = "^0.3.41"
-tokio = "^1.45.0"
+tokio = "^1.47.1"
 tracing-subscriber = { version = "^0.3.19", features = ["env-filter", "time"] }
 
 [features]


### PR DESCRIPTION
## What does this change?

- Enable to use retry policy in all operations.
- update dependencies.

## References

- N/A

## Screenshots

- N/A

## What can I check for bug fixes?

- N/A

## Summary by Copilot

This pull request introduces enhanced retry support and more flexible error handling for DynamoDB operations in the `raiden-derive` crate. The changes refactor the generated code for batch and single-item operations to accept retry policies and conditions, and to perform retries using these policies. Additionally, the code is updated for improved consistency and maintainability, including updates to dependencies and minor workflow adjustments.

**Retry and Error Handling Improvements:**

* All builder structs for batch and single-item operations (`batch_get`, `batch_delete`, `delete_item`, `scan`) now include `policy` and `condition` fields, allowing for customizable retry logic. The `run` methods have been refactored to use these policies with the `retry_if` method, improving resilience against transient errors. [[1]](diffhunk://#diff-d58cc650308daf62c113f3e0a8c48b00e44f818fbb088cea31acac65f9d97eddL51-R53) [[2]](diffhunk://#diff-d58cc650308daf62c113f3e0a8c48b00e44f818fbb088cea31acac65f9d97eddL133-R145) [[3]](diffhunk://#diff-d58cc650308daf62c113f3e0a8c48b00e44f818fbb088cea31acac65f9d97eddL149-R197) [[4]](diffhunk://#diff-d58cc650308daf62c113f3e0a8c48b00e44f818fbb088cea31acac65f9d97eddL191-R212) [[5]](diffhunk://#diff-d58cc650308daf62c113f3e0a8c48b00e44f818fbb088cea31acac65f9d97eddL209-R224) [[6]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdR51-R52) [[7]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdR91-R92) [[8]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdR119-R134) [[9]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdL135-R161) [[10]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdL164-R190) [[11]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdL185-R202) [[12]](diffhunk://#diff-20f94bacf6e4649a4c0f221107b953d856f0a032bb12b959fcaeca90c5da89f4R36-R37) [[13]](diffhunk://#diff-20f94bacf6e4649a4c0f221107b953d856f0a032bb12b959fcaeca90c5da89f4R59-R60) [[14]](diffhunk://#diff-20f94bacf6e4649a4c0f221107b953d856f0a032bb12b959fcaeca90c5da89f4R86-R87) [[15]](diffhunk://#diff-20f94bacf6e4649a4c0f221107b953d856f0a032bb12b959fcaeca90c5da89f4L103-R120) [[16]](diffhunk://#diff-080e0bfd6499f275e47542b0a81319d716659a5cb8c235efdd83e3a84059a874L36-R38) [[17]](diffhunk://#diff-080e0bfd6499f275e47542b0a81319d716659a5cb8c235efdd83e3a84059a874R53-R54)

* The internal call signatures and builder field usage have been updated to pass and use owned values instead of references where appropriate, reducing lifetime complexity and improving code clarity. [[1]](diffhunk://#diff-d58cc650308daf62c113f3e0a8c48b00e44f818fbb088cea31acac65f9d97eddL115-R122) [[2]](diffhunk://#diff-2826ddd505db1ca448fe89e58e21ebce70d2ae7029fe26d94d45482a0f2b5cbdL98-R107) [[3]](diffhunk://#diff-20f94bacf6e4649a4c0f221107b953d856f0a032bb12b959fcaeca90c5da89f4L66-R75) [[4]](diffhunk://#diff-080e0bfd6499f275e47542b0a81319d716659a5cb8c235efdd83e3a84059a874L17-R22)

**Dependency and Workflow Updates:**

* Updated `syn` dependency in `raiden-derive/Cargo.toml` from `^2.0.101` to `^2.0.104`.
* Updated the Deno setup action in the GitHub Actions workflow to use a newer commit for improved reliability.

These changes collectively make the codebase more robust, maintainable, and ready for advanced retry strategies in DynamoDB operations.