### PR TITLE
[codex] Support tagged enum documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,56 @@ Notes:
 
 - map key is currently limited to `String`
 - use `#[derive(RaidenDocument)]` when you want to store a nested type directly as a field
+- enums can also derive `RaidenDocument`; serde enum tagging such as `#[serde(tag = "type")]` is preserved when values are encoded into DynamoDB maps and decoded back
 - `Document<T>` remains available as an explicit wrapper when you prefer opt-in at the field type level
 - empty maps are preserved as empty DynamoDB `M` values rather than being dropped
+
+Tagged enums can be stored directly as nested document fields:
+
+```rust
+use std::collections::HashMap;
+
+use raiden::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, RaidenDocument)]
+#[serde(tag = "type")]
+enum Message {
+    Request {
+        id: String,
+        method: String,
+        params: HashMap<String, usize>,
+    },
+    Response {
+        id: String,
+        result: String,
+    },
+}
+
+#[derive(Raiden)]
+#[raiden(table_name = "event")]
+struct Event {
+    #[raiden(partition_key)]
+    id: String,
+    message: Message,
+}
+
+fn input() -> EventPutItemInput {
+    let mut params = HashMap::new();
+    params.insert("attempt".to_owned(), 1);
+
+    Event::put_item_builder()
+        .id("event#1".to_owned())
+        .message(Message::Request {
+            id: "msg#1".to_owned(),
+            method: "send".to_owned(),
+            params,
+        })
+        .build()
+}
+```
+
+When a tagged enum is used as the item type itself, the DynamoDB item map is decoded through serde as a whole document. This allows projection reads such as `query().project::<Message>()` when the item contains the tag and variant fields at the top level.
 
 #### query nested map and document values
 

--- a/raiden-derive/src/lib.rs
+++ b/raiden-derive/src/lib.rs
@@ -761,11 +761,62 @@ pub fn derive_raiden_index(input: TokenStream) -> TokenStream {
 pub fn derive_raiden_document(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);
     let struct_name = input.ident;
+    let common_impls = quote! {
+        impl ::raiden::IntoDocumentAttr for #struct_name {}
+
+        impl ::raiden::FromDocumentAttr for #struct_name {}
+
+        impl ::raiden::IntoAttribute for #struct_name {
+            fn into_attr(self) -> ::raiden::AttributeValue {
+                <Self as ::raiden::IntoDocumentAttr>::into_document_attr(self)
+                    .expect(concat!(
+                        "RaidenDocument serialization failed for `",
+                        stringify!(#struct_name),
+                        "`."
+                    ))
+            }
+        }
+
+        impl ::raiden::FromAttribute for #struct_name {
+            fn from_attr(
+                value: Option<::raiden::AttributeValue>,
+            ) -> Result<Self, ::raiden::ConversionError> {
+                <Self as ::raiden::FromDocumentAttr>::from_document_attr(value)
+            }
+        }
+    };
+
     let fields = match input.data {
         Data::Struct(DataStruct {
             fields: Fields::Named(n),
             ..
         }) => n,
+        Data::Enum(_) => {
+            let expanded = quote! {
+                #common_impls
+
+                impl ::raiden::RaidenItem for #struct_name {
+                    fn attribute_names() -> Option<::raiden::AttributeNames> {
+                        None
+                    }
+
+                    fn projection_expression() -> Option<String> {
+                        None
+                    }
+
+                    fn from_item(
+                        item: ::raiden::AttributeValues,
+                    ) -> Result<Self, ::raiden::RaidenError> {
+                        ::raiden::deserialize_document_item(item)
+                            .map_err(|err| ::raiden::RaidenError::AttributeConvertError {
+                                attr_name: err.to_string(),
+                            })
+                    }
+                }
+            };
+
+            return proc_macro::TokenStream::from(expanded);
+        }
         _ => unimplemented!(),
     };
     let attr_enum_name = format_ident!("{}DocumentAttrNames", struct_name);
@@ -823,28 +874,7 @@ pub fn derive_raiden_document(input: TokenStream) -> TokenStream {
             )*
         }
 
-        impl ::raiden::IntoDocumentAttr for #struct_name {}
-
-        impl ::raiden::FromDocumentAttr for #struct_name {}
-
-        impl ::raiden::IntoAttribute for #struct_name {
-            fn into_attr(self) -> ::raiden::AttributeValue {
-                <Self as ::raiden::IntoDocumentAttr>::into_document_attr(self)
-                    .expect(concat!(
-                        "RaidenDocument serialization failed for `",
-                        stringify!(#struct_name),
-                        "`."
-                    ))
-            }
-        }
-
-        impl ::raiden::FromAttribute for #struct_name {
-            fn from_attr(
-                value: Option<::raiden::AttributeValue>,
-            ) -> Result<Self, ::raiden::ConversionError> {
-                <Self as ::raiden::FromDocumentAttr>::from_document_attr(value)
-            }
-        }
+        #common_impls
     };
 
     proc_macro::TokenStream::from(expanded)

--- a/raiden/src/document.rs
+++ b/raiden/src/document.rs
@@ -249,6 +249,13 @@ pub(crate) fn deserialize_document<T: DeserializeOwned>(
     serde_json::from_value(value).map_err(|err| ConversionError::Serde(err.to_string()))
 }
 
+#[doc(hidden)]
+pub fn deserialize_document_item<T: DeserializeOwned>(
+    item: crate::AttributeValues,
+) -> Result<T, ConversionError> {
+    deserialize_document(Some(attr_map(item)))
+}
+
 #[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
 pub(crate) fn attribute_value_to_json_value(
     value: AttributeValue,

--- a/raiden/tests/all/document.rs
+++ b/raiden/tests/all/document.rs
@@ -17,6 +17,27 @@ mod tests {
         level: usize,
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, RaidenDocument)]
+    #[serde(tag = "type")]
+    pub enum Message {
+        Request {
+            id: String,
+            method: String,
+            params: HashMap<String, usize>,
+        },
+        Response {
+            id: String,
+            result: String,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, RaidenDocument)]
+    #[serde(tag = "kind", rename_all = "snake_case")]
+    pub enum RenamedMessage {
+        SendRequest { id: String },
+        SendResponse { id: String },
+    }
+
     #[derive(Raiden)]
     #[raiden(table_name = "user")]
     #[derive(Debug, Clone, PartialEq)]
@@ -37,6 +58,15 @@ mod tests {
         id: String,
         profile: DerivedProfile,
         profiles: HashMap<String, DerivedProfile>,
+    }
+
+    #[derive(Raiden)]
+    #[raiden(table_name = "user")]
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UserWithEnumDocument {
+        #[raiden(partition_key)]
+        id: String,
+        message: Message,
     }
 
     fn sample_profile() -> Profile {
@@ -91,6 +121,24 @@ mod tests {
         profiles
     }
 
+    fn sample_message() -> Message {
+        let mut params = HashMap::new();
+        params.insert("attempt".to_owned(), 3);
+
+        Message::Request {
+            id: "msg#1".to_owned(),
+            method: "send".to_owned(),
+            params,
+        }
+    }
+
+    fn sample_response_message() -> Message {
+        Message::Response {
+            id: "msg#2".to_owned(),
+            result: "ok".to_owned(),
+        }
+    }
+
     #[test]
     fn test_from_item_with_document_and_maps() {
         let metadata = sample_metadata();
@@ -138,6 +186,174 @@ mod tests {
                 profiles,
             }
         );
+    }
+
+    #[test]
+    fn test_from_item_with_raiden_document_enum() {
+        let message = sample_message();
+
+        let mut item = HashMap::new();
+        item.insert("id".to_owned(), "user#message".to_owned().into_attr());
+        item.insert("message".to_owned(), message.clone().into_attr());
+
+        assert_eq!(
+            UserWithEnumDocument::from_item(item).unwrap(),
+            UserWithEnumDocument {
+                id: "user#message".to_owned(),
+                message,
+            }
+        );
+    }
+
+    #[test]
+    fn test_from_item_with_raiden_document_enum_response_variant() {
+        let message = sample_response_message();
+
+        let mut item = HashMap::new();
+        item.insert("id".to_owned(), "user#response".to_owned().into_attr());
+        item.insert("message".to_owned(), message.clone().into_attr());
+
+        assert_eq!(
+            UserWithEnumDocument::from_item(item).unwrap(),
+            UserWithEnumDocument {
+                id: "user#response".to_owned(),
+                message,
+            }
+        );
+    }
+
+    #[test]
+    fn test_from_item_with_raiden_document_enum_empty_map_payload() {
+        let message = Message::Request {
+            id: "msg#empty".to_owned(),
+            method: "send".to_owned(),
+            params: HashMap::new(),
+        };
+
+        let mut item = HashMap::new();
+        item.insert("id".to_owned(), "user#empty-message".to_owned().into_attr());
+        item.insert("message".to_owned(), message.clone().into_attr());
+
+        assert_eq!(
+            UserWithEnumDocument::from_item(item).unwrap(),
+            UserWithEnumDocument {
+                id: "user#empty-message".to_owned(),
+                message,
+            }
+        );
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_attribute_round_trip() {
+        for message in [sample_message(), sample_response_message()] {
+            let attr = message.clone().into_attr();
+            let decoded = Message::from_attr(Some(attr)).unwrap();
+
+            assert_eq!(decoded, message);
+        }
+    }
+
+    #[test]
+    fn test_document_wrapper_with_tagged_enum_round_trip() {
+        for message in [sample_message(), sample_response_message()] {
+            let document = Document::new(message);
+            let attr = document.clone().into_attr();
+            let decoded = Document::<Message>::from_attr(Some(attr)).unwrap();
+
+            assert_eq!(decoded, document);
+        }
+    }
+
+    #[test]
+    fn test_raiden_document_enum_attribute_names_are_unprojected() {
+        assert_eq!(Message::attribute_names(), None);
+        assert_eq!(Message::projection_expression(), None);
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_item() {
+        let mut params = HashMap::new();
+        params.insert("attempt".to_owned(), 3);
+
+        let mut item = HashMap::new();
+        item.insert("type".to_owned(), "Request".to_owned().into_attr());
+        item.insert("id".to_owned(), "msg#1".to_owned().into_attr());
+        item.insert("method".to_owned(), "send".to_owned().into_attr());
+        item.insert("params".to_owned(), params.clone().into_attr());
+
+        assert_eq!(
+            Message::from_item(item).unwrap(),
+            Message::Request {
+                id: "msg#1".to_owned(),
+                method: "send".to_owned(),
+                params,
+            }
+        );
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_item_preserves_serde_variant_rename_all() {
+        let mut item = HashMap::new();
+        item.insert("kind".to_owned(), "send_request".to_owned().into_attr());
+        item.insert("id".to_owned(), "msg#renamed".to_owned().into_attr());
+
+        assert_eq!(
+            RenamedMessage::from_item(item).unwrap(),
+            RenamedMessage::SendRequest {
+                id: "msg#renamed".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_item_response_variant() {
+        let mut item = HashMap::new();
+        item.insert("type".to_owned(), "Response".to_owned().into_attr());
+        item.insert("id".to_owned(), "msg#2".to_owned().into_attr());
+        item.insert("result".to_owned(), "ok".to_owned().into_attr());
+
+        assert_eq!(
+            Message::from_item(item).unwrap(),
+            Message::Response {
+                id: "msg#2".to_owned(),
+                result: "ok".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_item_rejects_unknown_tag() {
+        let mut item = HashMap::new();
+        item.insert("type".to_owned(), "Unknown".to_owned().into_attr());
+        item.insert("id".to_owned(), "msg#unknown".to_owned().into_attr());
+
+        assert!(Message::from_item(item).is_err());
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_item_rejects_missing_tag() {
+        let mut item = HashMap::new();
+        item.insert("id".to_owned(), "msg#missing-tag".to_owned().into_attr());
+        item.insert("method".to_owned(), "send".to_owned().into_attr());
+        item.insert(
+            "params".to_owned(),
+            HashMap::<String, usize>::new().into_attr(),
+        );
+
+        assert!(Message::from_item(item).is_err());
+    }
+
+    #[test]
+    fn test_raiden_document_enum_from_item_rejects_missing_required_field() {
+        let mut item = HashMap::new();
+        item.insert("type".to_owned(), "Request".to_owned().into_attr());
+        item.insert("id".to_owned(), "msg#missing-field".to_owned().into_attr());
+        item.insert(
+            "params".to_owned(),
+            HashMap::<String, usize>::new().into_attr(),
+        );
+
+        assert!(Message::from_item(item).is_err());
     }
 
     #[tokio::test]
@@ -244,5 +460,29 @@ mod tests {
         assert_eq!(item.get("id"), Some(&"user#derived".to_owned().into_attr()));
         assert_eq!(item.get("profile"), Some(&profile.into_attr()));
         assert_eq!(item.get("profiles"), Some(&profiles.into_attr()));
+    }
+
+    #[tokio::test]
+    async fn test_put_input_with_raiden_document_enum() {
+        let client = crate::all::create_client_from_struct!(UserWithEnumDocument);
+        let message = sample_message();
+
+        let input_item = UserWithEnumDocumentPutItemInput {
+            id: "user#message".to_owned(),
+            message: message.clone(),
+        };
+
+        #[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
+        let input = client.put(input_item).input;
+        #[cfg(feature = "aws-sdk")]
+        let input = client.put(input_item).builder.build().unwrap();
+
+        #[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
+        let item = input.item;
+        #[cfg(feature = "aws-sdk")]
+        let item = input.item.unwrap();
+
+        assert_eq!(item.get("id"), Some(&"user#message".to_owned().into_attr()));
+        assert_eq!(item.get("message"), Some(&message.into_attr()));
     }
 }


### PR DESCRIPTION
## Summary

- Allow `#[derive(RaidenDocument)]` on enums, delegating tagged enum encoding and decoding to serde.
- Add whole-item document deserialization so a tagged enum can implement `RaidenItem` and be used as a projected query or scan item.
- Cover internally tagged enum fields and direct item mapping in document tests.

## Validation

- `cargo test -p raiden document`
- `cargo test -p raiden --no-default-features --features aws-sdk document`