### PR TITLE
Add BatchPut and TransactGetItems support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,65 @@ async fn main() {
 }
 ```
 
+#### batch_put
+
+```rust
+use raiden::*;
+
+#[derive(Raiden, Debug, PartialEq)]
+pub struct User {
+    #[raiden(partition_key)]
+    id: String,
+    #[raiden(sort_key)]
+    year: usize,
+    name: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let client = /* generate client */;
+    let items = vec![
+        User::put_item_builder()
+            .id("Alice".to_owned())
+            .year(1992)
+            .name("Alice".to_owned())
+            .build(),
+        User::put_item_builder()
+            .id("Bob".to_owned())
+            .year(1976)
+            .name("Bob".to_owned())
+            .build(),
+    ];
+
+    let res = client.batch_put(items).run().await;
+}
+```
+
+#### transact_get_items
+
+```rust
+use raiden::*;
+
+#[derive(Raiden, Debug, PartialEq)]
+pub struct User {
+    #[raiden(partition_key)]
+    id: String,
+    #[raiden(sort_key)]
+    year: usize,
+    name: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let client = /* generate client */;
+    let keys: Vec<(&str, usize)> = vec![("Alice", 1992), ("Bob", 1976)];
+    let res = client.transact_get(keys).run().await;
+
+    // Responses preserve the request order.
+    // Missing items are returned as `None`.
+}
+```
+
 #### query with typed GSI
 
 ```rust
@@ -532,13 +591,13 @@ Then open `http://localhost:8001` in browser.
 ### Item
 
 - [x] BatchGetItem
-- [ ] BatchWriteItem
+- [x] BatchWriteItem
 - [x] DeleteItem
 - [x] GetItem
 - [x] PutItem
 - [x] Query
 - [x] Scan
-- [ ] TransactGetItems
+- [x] TransactGetItems
 - [x] TransactWriteItems
 - [x] UpdateItem
 

--- a/raiden-derive/src/aws_sdk/ops/batch_put.rs
+++ b/raiden-derive/src/aws_sdk/ops/batch_put.rs
@@ -1,0 +1,150 @@
+use crate::rename::*;
+use quote::*;
+use syn::*;
+
+pub(crate) fn expand_batch_put(
+    struct_name: &Ident,
+    fields: &FieldsNamed,
+    rename_all_type: RenameAllType,
+) -> proc_macro2::TokenStream {
+    let item_input_name = format_ident!("{}PutItemInput", struct_name);
+    let trait_name = format_ident!("{}BatchPut", struct_name);
+    let client_name = format_ident!("{}Client", struct_name);
+    let builder_name = format_ident!("{}BatchPutBuilder", struct_name);
+
+    let input_items = {
+        let insertion = fields.named.iter().map(|f| {
+            let ident = &f.ident.clone().unwrap();
+            let renamed = crate::finder::find_rename_value(&f.attrs);
+            let attr_key = create_renamed(ident.to_string(), renamed, rename_all_type);
+            if crate::finder::include_unary_attr(&f.attrs, "uuid") {
+                quote! {
+                    let id = #struct_name::gen();
+                    input_item.insert(#attr_key.to_string(), id.into_attr());
+                }
+            } else {
+                quote! {
+                    let value = item.#ident.clone().into_attr();
+                    if !::raiden::is_attr_value_empty(&value) {
+                        input_item.insert(#attr_key.to_string(), value);
+                    }
+                }
+            }
+        });
+
+        quote! {
+            let mut input_item: std::collections::HashMap<String, ::raiden::aws_sdk::types::AttributeValue> = std::collections::HashMap::new();
+            #(#insertion)*
+        }
+    };
+
+    let api_call_token = super::api_call_token!("batch_write_item");
+    let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
+        (
+            quote! { #builder_name::inner_run(&self.table_name, &self.client, builder).await? },
+            quote! { table_name: &str, },
+        )
+    } else {
+        (
+            quote! { #builder_name::inner_run(&self.client, builder).await? },
+            quote! {},
+        )
+    };
+
+    quote! {
+        pub trait #trait_name {
+            fn batch_put(&self, items: std::vec::Vec<#item_input_name>) -> #builder_name;
+        }
+
+        impl #trait_name for #client_name {
+            fn batch_put(&self, items: std::vec::Vec<#item_input_name>) -> #builder_name {
+                let write_requests = {
+                    let mut write_requests = vec![];
+                    for item in items.into_iter() {
+                        #input_items
+
+                        let put_request = ::raiden::aws_sdk::types::PutRequest::builder()
+                            .set_item(Some(input_item))
+                            .build()
+                            .expect("should be built");
+
+                        let write_request = ::raiden::aws_sdk::types::WriteRequest::builder()
+                            .put_request(put_request)
+                            .build();
+
+                        write_requests.push(write_request);
+                    }
+
+                    write_requests
+                };
+
+                #builder_name {
+                    client: &self.client,
+                    write_requests,
+                    table_name: self.table_name(),
+                }
+            }
+        }
+
+        pub struct #builder_name<'a> {
+            pub client: &'a ::raiden::Client,
+            pub write_requests: ::std::vec::Vec<::raiden::aws_sdk::types::WriteRequest>,
+            pub table_name: String,
+        }
+
+        impl<'a> #builder_name<'a> {
+            pub async fn run(mut self) -> Result<::raiden::batch_put::BatchPutOutput, ::raiden::RaidenError> {
+                const RETRY: usize = 5;
+                const MAX_ITEMS_PER_REQUEST: usize = 25;
+
+                for _ in 0..RETRY {
+                    loop {
+                        let len = self.write_requests.len();
+                        if len == 0 {
+                            break;
+                        }
+
+                        let start = len.saturating_sub(MAX_ITEMS_PER_REQUEST);
+                        let end = std::cmp::min(len, start + MAX_ITEMS_PER_REQUEST);
+                        let req = self.write_requests.drain(start..end).collect::<std::vec::Vec<_>>();
+                        let request_items = vec![(self.table_name.clone(), req)]
+                            .into_iter()
+                            .collect::<std::collections::HashMap<_, _>>();
+                        let builder = ::raiden::aws_sdk::operation::batch_write_item::BatchWriteItemInput::builder()
+                            .set_request_items(Some(request_items));
+
+                        let result = #call_inner_run;
+
+                        let mut unprocessed_items = match result.unprocessed_items {
+                            None => continue,
+                            Some(unprocessed_items) if unprocessed_items.is_empty() => continue,
+                            Some(unprocessed_items) => unprocessed_items,
+                        };
+
+                        let unprocessed_requests = unprocessed_items
+                            .remove(&self.table_name)
+                            .expect("request_items hashmap must have a value for the table name");
+                        self.write_requests.extend(unprocessed_requests);
+                    }
+                }
+
+                let unprocessed_items = self.write_requests
+                    .into_iter()
+                    .filter_map(|write_request| write_request.put_request)
+                    .collect::<std::vec::Vec<_>>();
+                Ok(::raiden::batch_put::BatchPutOutput {
+                    consumed_capacity: None,
+                    unprocessed_items,
+                })
+            }
+
+            async fn inner_run(
+                #inner_run_args
+                client: &::raiden::Client,
+                builder: ::raiden::operation::batch_write_item::builders::BatchWriteItemInputBuilder,
+            ) -> Result<::raiden::operation::batch_write_item::BatchWriteItemOutput, ::raiden::RaidenError> {
+                Ok(#api_call_token?)
+            }
+        }
+    }
+}

--- a/raiden-derive/src/aws_sdk/ops/mod.rs
+++ b/raiden-derive/src/aws_sdk/ops/mod.rs
@@ -1,21 +1,25 @@
 mod batch_delete;
 mod batch_get;
+mod batch_put;
 mod delete;
 mod get;
 mod put;
 mod query;
 mod scan;
 mod shared;
+mod transact_get;
 mod transact_write;
 mod update;
 
 pub(crate) use batch_delete::*;
 pub(crate) use batch_get::*;
+pub(crate) use batch_put::*;
 pub(crate) use delete::*;
 pub(crate) use get::*;
 pub(crate) use put::*;
 pub(crate) use query::*;
 pub(crate) use scan::*;
 pub(crate) use shared::*;
+pub(crate) use transact_get::*;
 pub(crate) use transact_write::*;
 pub(crate) use update::*;

--- a/raiden-derive/src/aws_sdk/ops/transact_get.rs
+++ b/raiden-derive/src/aws_sdk/ops/transact_get.rs
@@ -1,0 +1,179 @@
+use proc_macro2::*;
+use quote::*;
+use syn::*;
+
+pub(crate) fn expand_transact_get(
+    partition_key: &(Ident, Type),
+    sort_key: &Option<(Ident, Type)>,
+    struct_name: &Ident,
+    fields: &FieldsNamed,
+    rename_all_type: crate::rename::RenameAllType,
+) -> TokenStream {
+    let trait_name = format_ident!("{}TransactGetItems", struct_name);
+    let client_name = format_ident!("{}Client", struct_name);
+    let builder_name = format_ident!("{}TransactGetItemsBuilder", struct_name);
+    let from_item = super::expand_attr_to_item(format_ident!("res_item"), fields, rename_all_type);
+    let (partition_key_ident, partition_key_type) = partition_key;
+
+    let builder_keys_type = if sort_key.is_none() {
+        quote! { std::vec::Vec<::raiden::aws_sdk::types::AttributeValue> }
+    } else {
+        quote! { std::vec::Vec<(::raiden::aws_sdk::types::AttributeValue, ::raiden::aws_sdk::types::AttributeValue)> }
+    };
+
+    let client_trait = if let Some(sort_key) = sort_key {
+        let (_sort_key_ident, sort_key_type) = sort_key;
+        quote! {
+            pub trait #trait_name {
+                fn transact_get(&self, keys: std::vec::Vec<(impl Into<#partition_key_type>, impl Into<#sort_key_type>)>) -> #builder_name;
+            }
+
+            impl #trait_name for #client_name {
+                fn transact_get(&self, keys: std::vec::Vec<(impl Into<#partition_key_type>, impl Into<#sort_key_type>)>) -> #builder_name {
+                    let keys = keys.into_iter().map(|(pk, sk)| (pk.into().into_attr(), sk.into().into_attr())).collect();
+
+                    #builder_name {
+                        client: &self.client,
+                        table_name: self.table_name(),
+                        keys,
+                        attribute_names: self.attribute_names.clone(),
+                        projection_expression: self.projection_expression.clone(),
+                        policy: self.retry_condition.strategy.policy(),
+                        condition: &self.retry_condition,
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {
+            pub trait #trait_name {
+                fn transact_get(&self, keys: std::vec::Vec<impl Into<#partition_key_type>>) -> #builder_name;
+            }
+
+            impl #trait_name for #client_name {
+                fn transact_get(&self, keys: std::vec::Vec<impl Into<#partition_key_type>>) -> #builder_name {
+                    let keys = keys.into_iter().map(|key| key.into().into_attr()).collect();
+
+                    #builder_name {
+                        client: &self.client,
+                        table_name: self.table_name(),
+                        keys,
+                        attribute_names: self.attribute_names.clone(),
+                        projection_expression: self.projection_expression.clone(),
+                        policy: self.retry_condition.strategy.policy(),
+                        condition: &self.retry_condition,
+                    }
+                }
+            }
+        }
+    };
+
+    let push_gets = if let Some(sort_key) = sort_key {
+        let (sort_key_ident, _) = sort_key;
+        quote! {
+            for (pk_attr, sk_attr) in self.keys.into_iter() {
+                let key_set = ::std::collections::HashMap::from_iter([
+                    (stringify!(#partition_key_ident).to_owned(), pk_attr),
+                    (stringify!(#sort_key_ident).to_owned(), sk_attr),
+                ]);
+                let get = ::raiden::aws_sdk::types::Get::builder()
+                    .table_name(self.table_name.clone())
+                    .set_key(Some(key_set))
+                    .set_expression_attribute_names(self.attribute_names.clone())
+                    .set_projection_expression(self.projection_expression.clone())
+                    .build()
+                    .expect("should be built");
+                transact_items.push(::raiden::aws_sdk::types::TransactGetItem::builder().get(get).build());
+            }
+        }
+    } else {
+        quote! {
+            for key_attr in self.keys.into_iter() {
+                let key_set = ::std::collections::HashMap::from_iter([
+                    (stringify!(#partition_key_ident).to_owned(), key_attr),
+                ]);
+                let get = ::raiden::aws_sdk::types::Get::builder()
+                    .table_name(self.table_name.clone())
+                    .set_key(Some(key_set))
+                    .set_expression_attribute_names(self.attribute_names.clone())
+                    .set_projection_expression(self.projection_expression.clone())
+                    .build()
+                    .expect("should be built");
+                transact_items.push(::raiden::aws_sdk::types::TransactGetItem::builder().get(get).build());
+            }
+        }
+    };
+
+    let api_call_token = super::api_call_token!("transact_get_items");
+    let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
+        (
+            quote! { #builder_name::inner_run(table_name, client, builder).await },
+            quote! { table_name: String, },
+        )
+    } else {
+        (
+            quote! { #builder_name::inner_run(client, builder).await },
+            quote! {},
+        )
+    };
+
+    quote! {
+        #client_trait
+
+        pub struct #builder_name<'a> {
+            pub client: &'a ::raiden::Client,
+            pub table_name: String,
+            pub keys: #builder_keys_type,
+            pub attribute_names: Option<::raiden::AttributeNames>,
+            pub projection_expression: Option<String>,
+            pub policy: ::raiden::Policy,
+            pub condition: &'a ::raiden::retry::RetryCondition,
+        }
+
+        impl<'a> #builder_name<'a> {
+            pub async fn run(self) -> Result<::raiden::transact_get::TransactGetOutput<#struct_name>, ::raiden::RaidenError> {
+                let mut transact_items = vec![];
+                #push_gets
+
+                let builder = ::raiden::aws_sdk::operation::transact_get_items::TransactGetItemsInput::builder()
+                    .set_transact_items(Some(transact_items));
+
+                let policy: ::raiden::RetryPolicy = self.policy.into();
+                let client = self.client;
+                let table_name = self.table_name.clone();
+                let res = policy.retry_if(move || {
+                    let client = client.clone();
+                    let builder = builder.clone();
+                    let table_name = table_name.clone();
+                    async move { #call_inner_run }
+                }, self.condition).await?;
+
+                let items = res.responses
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|response| {
+                        match response.item {
+                            Some(mut res_item) => Ok(Some(#struct_name {
+                                #(#from_item)*
+                            })),
+                            None => Ok(None),
+                        }
+                    })
+                    .collect::<Result<std::vec::Vec<_>, ::raiden::RaidenError>>()?;
+
+                Ok(::raiden::transact_get::TransactGetOutput {
+                    consumed_capacity: res.consumed_capacity,
+                    items,
+                })
+            }
+
+            async fn inner_run(
+                #inner_run_args
+                client: ::raiden::Client,
+                builder: ::raiden::aws_sdk::operation::transact_get_items::builders::TransactGetItemsInputBuilder,
+            ) -> Result<::raiden::aws_sdk::operation::transact_get_items::TransactGetItemsOutput, ::raiden::RaidenError> {
+                Ok(#api_call_token?)
+            }
+        }
+    }
+}

--- a/raiden-derive/src/lib.rs
+++ b/raiden-derive/src/lib.rs
@@ -574,6 +574,8 @@ pub fn derive_raiden(input: TokenStream) -> TokenStream {
 
     let put_item = ops::expand_put_item(&struct_name, &fields, rename_all_type);
 
+    let batch_put = ops::expand_batch_put(&struct_name, &fields, rename_all_type);
+
     let update_item = ops::expand_update_item(
         &partition_key,
         &sort_key,
@@ -607,6 +609,14 @@ pub fn derive_raiden(input: TokenStream) -> TokenStream {
         &attr_enum_name,
         rename_all_type,
         &table_name,
+    );
+
+    let transact_get = ops::expand_transact_get(
+        &partition_key,
+        &sort_key,
+        &struct_name,
+        &fields,
+        rename_all_type,
     );
 
     let client_constructor = client::expand_client_constructor(
@@ -662,11 +672,15 @@ pub fn derive_raiden(input: TokenStream) -> TokenStream {
 
         #put_item
 
+        #batch_put
+
         #update_item
 
         #delete_item
 
         #batch_delete
+
+        #transact_get
 
         #transact_write
 

--- a/raiden-derive/src/rusoto/ops/batch_put.rs
+++ b/raiden-derive/src/rusoto/ops/batch_put.rs
@@ -1,0 +1,161 @@
+use crate::rename::*;
+use quote::*;
+use syn::*;
+
+pub(crate) fn expand_batch_put(
+    struct_name: &Ident,
+    fields: &FieldsNamed,
+    rename_all_type: RenameAllType,
+) -> proc_macro2::TokenStream {
+    let item_input_name = format_ident!("{}PutItemInput", struct_name);
+    let trait_name = format_ident!("{}BatchPut", struct_name);
+    let client_name = format_ident!("{}Client", struct_name);
+    let builder_name = format_ident!("{}BatchPutBuilder", struct_name);
+
+    let input_items = {
+        let insertion = fields.named.iter().map(|f| {
+            let ident = &f.ident.clone().unwrap();
+            let renamed = crate::finder::find_rename_value(&f.attrs);
+            let attr_key = create_renamed(ident.to_string(), renamed, rename_all_type);
+            if crate::finder::include_unary_attr(&f.attrs, "uuid") {
+                quote! {
+                    let id = #struct_name::gen();
+                    input_item.insert(#attr_key.to_string(), id.into_attr());
+                }
+            } else {
+                quote! {
+                    let value = item.#ident.clone().into_attr();
+                    if !::raiden::is_attr_value_empty(&value) {
+                        input_item.insert(#attr_key.to_string(), value);
+                    }
+                }
+            }
+        });
+
+        quote! {
+            let mut input_item: std::collections::HashMap<String, ::raiden::AttributeValue> = std::collections::HashMap::new();
+            #(#insertion)*
+        }
+    };
+
+    let api_call_token = super::api_call_token!("batch_write_item");
+    let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
+        (
+            quote! { #builder_name::inner_run(table_name, client, input).await },
+            quote! { table_name: String, },
+        )
+    } else {
+        (
+            quote! { #builder_name::inner_run(client, input).await },
+            quote! {},
+        )
+    };
+
+    quote! {
+        pub trait #trait_name {
+            fn batch_put(&self, items: std::vec::Vec<#item_input_name>) -> #builder_name;
+        }
+
+        impl #trait_name for #client_name {
+            fn batch_put(&self, items: std::vec::Vec<#item_input_name>) -> #builder_name {
+                let write_requests = {
+                    let mut write_requests = vec![];
+                    for item in items.into_iter() {
+                        #input_items
+
+                        let mut write_request = ::raiden::WriteRequest::default();
+                        write_request.put_request = Some(::raiden::PutRequest {
+                            item: input_item,
+                        });
+                        write_requests.push(write_request);
+                    }
+
+                    write_requests
+                };
+
+                #builder_name {
+                    client: &self.client,
+                    write_requests,
+                    table_name: self.table_name(),
+                    policy: self.retry_condition.strategy.policy(),
+                    condition: &self.retry_condition,
+                }
+            }
+        }
+
+        pub struct #builder_name<'a> {
+            pub client: &'a ::raiden::DynamoDbClient,
+            pub write_requests: std::vec::Vec<::raiden::WriteRequest>,
+            pub table_name: String,
+            pub policy: ::raiden::Policy,
+            pub condition: &'a ::raiden::retry::RetryCondition,
+        }
+
+        impl<'a> #builder_name<'a> {
+            pub async fn run(self) -> Result<::raiden::batch_put::BatchPutOutput, ::raiden::RaidenError> {
+                let Self { client, mut write_requests, table_name, policy, condition } = self;
+                let policy: ::raiden::RetryPolicy = policy.into();
+
+                const RETRY: usize = 5;
+                const MAX_ITEMS_PER_REQUEST: usize = 25;
+
+                for _ in 0..RETRY {
+                    loop {
+                        let len = write_requests.len();
+                        if len == 0 {
+                            break;
+                        }
+
+                        let start = len.saturating_sub(MAX_ITEMS_PER_REQUEST);
+                        let end = std::cmp::min(len, start + MAX_ITEMS_PER_REQUEST);
+                        let req = write_requests.drain(start..end).collect::<std::vec::Vec<_>>();
+                        let request_items = vec![(table_name.clone(), req)]
+                            .into_iter()
+                            .collect::<std::collections::HashMap<_, _>>();
+                        let result = {
+                            let t = table_name.clone();
+                            let c = client.clone();
+                            let i = ::raiden::BatchWriteItemInput {
+                                request_items,
+                                ..std::default::Default::default()
+                            };
+
+                            policy.retry_if(move || {
+                                let (table_name, client, input) = (t.clone(), c.clone(), i.clone());
+                                async move { #call_inner_run }
+                            }, condition).await?
+                        };
+
+                        let mut unprocessed_items = match result.unprocessed_items {
+                            None => continue,
+                            Some(unprocessed_items) if unprocessed_items.is_empty() => continue,
+                            Some(unprocessed_items) => unprocessed_items,
+                        };
+
+                        let unprocessed_requests = unprocessed_items
+                            .remove(&table_name)
+                            .expect("request_items hashmap must have a value for the table name");
+                        write_requests.extend(unprocessed_requests);
+                    }
+                }
+
+                let unprocessed_items = write_requests
+                    .into_iter()
+                    .filter_map(|write_request| write_request.put_request)
+                    .collect::<std::vec::Vec<_>>();
+                Ok(::raiden::batch_put::BatchPutOutput {
+                    consumed_capacity: None,
+                    unprocessed_items,
+                })
+            }
+
+            async fn inner_run(
+                #inner_run_args
+                client: ::raiden::DynamoDbClient,
+                input: ::raiden::BatchWriteItemInput,
+            ) -> Result<::raiden::BatchWriteItemOutput, ::raiden::RaidenError> {
+                Ok(#api_call_token?)
+            }
+        }
+    }
+}

--- a/raiden-derive/src/rusoto/ops/mod.rs
+++ b/raiden-derive/src/rusoto/ops/mod.rs
@@ -1,21 +1,25 @@
 mod batch_delete;
 mod batch_get;
+mod batch_put;
 mod delete;
 mod get;
 mod put;
 mod query;
 mod scan;
 mod shared;
+mod transact_get;
 mod transact_write;
 mod update;
 
 pub(crate) use batch_delete::*;
 pub(crate) use batch_get::*;
+pub(crate) use batch_put::*;
 pub(crate) use delete::*;
 pub(crate) use get::*;
 pub(crate) use put::*;
 pub(crate) use query::*;
 pub(crate) use scan::*;
 pub(crate) use shared::*;
+pub(crate) use transact_get::*;
 pub(crate) use transact_write::*;
 pub(crate) use update::*;

--- a/raiden-derive/src/rusoto/ops/transact_get.rs
+++ b/raiden-derive/src/rusoto/ops/transact_get.rs
@@ -1,0 +1,181 @@
+use proc_macro2::*;
+use quote::*;
+use syn::*;
+
+pub(crate) fn expand_transact_get(
+    partition_key: &(Ident, Type),
+    sort_key: &Option<(Ident, Type)>,
+    struct_name: &Ident,
+    fields: &FieldsNamed,
+    rename_all_type: crate::rename::RenameAllType,
+) -> TokenStream {
+    let trait_name = format_ident!("{}TransactGetItems", struct_name);
+    let client_name = format_ident!("{}Client", struct_name);
+    let builder_name = format_ident!("{}TransactGetItemsBuilder", struct_name);
+    let from_item = super::expand_attr_to_item(format_ident!("res_item"), fields, rename_all_type);
+    let (partition_key_ident, partition_key_type) = partition_key;
+
+    let builder_keys_type = if sort_key.is_none() {
+        quote! { std::vec::Vec<::raiden::AttributeValue> }
+    } else {
+        quote! { std::vec::Vec<(::raiden::AttributeValue, ::raiden::AttributeValue)> }
+    };
+
+    let client_trait = if let Some(sort_key) = sort_key {
+        let (_sort_key_ident, sort_key_type) = sort_key;
+        quote! {
+            pub trait #trait_name {
+                fn transact_get(&self, keys: std::vec::Vec<(impl Into<#partition_key_type>, impl Into<#sort_key_type>)>) -> #builder_name;
+            }
+
+            impl #trait_name for #client_name {
+                fn transact_get(&self, keys: std::vec::Vec<(impl Into<#partition_key_type>, impl Into<#sort_key_type>)>) -> #builder_name {
+                    let keys = keys.into_iter().map(|(pk, sk)| (pk.into().into_attr(), sk.into().into_attr())).collect();
+
+                    #builder_name {
+                        client: &self.client,
+                        table_name: self.table_name(),
+                        keys,
+                        attribute_names: self.attribute_names.clone(),
+                        projection_expression: self.projection_expression.clone(),
+                        policy: self.retry_condition.strategy.policy(),
+                        condition: &self.retry_condition,
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {
+            pub trait #trait_name {
+                fn transact_get(&self, keys: std::vec::Vec<impl Into<#partition_key_type>>) -> #builder_name;
+            }
+
+            impl #trait_name for #client_name {
+                fn transact_get(&self, keys: std::vec::Vec<impl Into<#partition_key_type>>) -> #builder_name {
+                    let keys = keys.into_iter().map(|key| key.into().into_attr()).collect();
+
+                    #builder_name {
+                        client: &self.client,
+                        table_name: self.table_name(),
+                        keys,
+                        attribute_names: self.attribute_names.clone(),
+                        projection_expression: self.projection_expression.clone(),
+                        policy: self.retry_condition.strategy.policy(),
+                        condition: &self.retry_condition,
+                    }
+                }
+            }
+        }
+    };
+
+    let push_gets = if let Some(sort_key) = sort_key {
+        let (sort_key_ident, _) = sort_key;
+        quote! {
+            for (pk_attr, sk_attr) in self.keys.into_iter() {
+                let key = vec![
+                    (stringify!(#partition_key_ident).to_owned(), pk_attr),
+                    (stringify!(#sort_key_ident).to_owned(), sk_attr),
+                ].into_iter().collect();
+                transact_items.push(::raiden::TransactGetItem {
+                    get: ::raiden::Get {
+                        expression_attribute_names: self.attribute_names.clone(),
+                        key,
+                        projection_expression: self.projection_expression.clone(),
+                        table_name: self.table_name.clone(),
+                    },
+                });
+            }
+        }
+    } else {
+        quote! {
+            for key_attr in self.keys.into_iter() {
+                let key = vec![
+                    (stringify!(#partition_key_ident).to_owned(), key_attr),
+                ].into_iter().collect();
+                transact_items.push(::raiden::TransactGetItem {
+                    get: ::raiden::Get {
+                        expression_attribute_names: self.attribute_names.clone(),
+                        key,
+                        projection_expression: self.projection_expression.clone(),
+                        table_name: self.table_name.clone(),
+                    },
+                });
+            }
+        }
+    };
+
+    let api_call_token = super::api_call_token!("transact_get_items");
+    let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
+        (
+            quote! { #builder_name::inner_run(table_name, client, input).await },
+            quote! { table_name: String, },
+        )
+    } else {
+        (
+            quote! { #builder_name::inner_run(client, input).await },
+            quote! {},
+        )
+    };
+
+    quote! {
+        #client_trait
+
+        pub struct #builder_name<'a> {
+            pub client: &'a ::raiden::DynamoDbClient,
+            pub table_name: String,
+            pub keys: #builder_keys_type,
+            pub attribute_names: Option<::raiden::AttributeNames>,
+            pub projection_expression: Option<String>,
+            pub policy: ::raiden::Policy,
+            pub condition: &'a ::raiden::retry::RetryCondition,
+        }
+
+        impl<'a> #builder_name<'a> {
+            pub async fn run(self) -> Result<::raiden::transact_get::TransactGetOutput<#struct_name>, ::raiden::RaidenError> {
+                let mut transact_items = vec![];
+                #push_gets
+
+                let input = ::raiden::TransactGetItemsInput {
+                    transact_items,
+                    ..std::default::Default::default()
+                };
+
+                let policy: ::raiden::RetryPolicy = self.policy.into();
+                let client = self.client;
+                let table_name = self.table_name.clone();
+                let res = policy.retry_if(move || {
+                    let client = client.clone();
+                    let input = input.clone();
+                    let table_name = table_name.clone();
+                    async { #call_inner_run }
+                }, self.condition).await?;
+
+                let items = res.responses
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|response| {
+                        match response.item {
+                            Some(mut res_item) => Ok(Some(#struct_name {
+                                #(#from_item)*
+                            })),
+                            None => Ok(None),
+                        }
+                    })
+                    .collect::<Result<std::vec::Vec<_>, ::raiden::RaidenError>>()?;
+
+                Ok(::raiden::transact_get::TransactGetOutput {
+                    consumed_capacity: res.consumed_capacity,
+                    items,
+                })
+            }
+
+            async fn inner_run(
+                #inner_run_args
+                client: ::raiden::DynamoDbClient,
+                input: ::raiden::TransactGetItemsInput,
+            ) -> Result<::raiden::TransactGetItemsOutput, ::raiden::RaidenError> {
+                Ok(#api_call_token?)
+            }
+        }
+    }
+}

--- a/raiden/src/aws_sdk/errors.rs
+++ b/raiden/src/aws_sdk/errors.rs
@@ -4,8 +4,8 @@ use crate::{
         operation::{
             batch_get_item::BatchGetItemError, batch_write_item::BatchWriteItemError,
             delete_item::DeleteItemError, get_item::GetItemError, put_item::PutItemError,
-            query::QueryError, scan::ScanError, transact_write_items::TransactWriteItemsError,
-            update_item::UpdateItemError,
+            query::QueryError, scan::ScanError, transact_get_items::TransactGetItemsError,
+            transact_write_items::TransactWriteItemsError, update_item::UpdateItemError,
         },
     },
     RaidenError, RaidenTransactionCancellationReasons,
@@ -289,6 +289,49 @@ impl From<SdkError<TransactWriteItemsError>> for RaidenError {
                 }
                 TransactWriteItemsError::TransactionInProgressException(err) => {
                     RaidenError::TransactionInProgress(err.to_string())
+                }
+                _ => into_raiden_error(error),
+            },
+            _ => into_raiden_error(error),
+        }
+    }
+}
+
+impl From<SdkError<TransactGetItemsError>> for RaidenError {
+    fn from(error: SdkError<TransactGetItemsError>) -> Self {
+        match &error {
+            SdkError::ServiceError(err) => match err.err() {
+                TransactGetItemsError::InternalServerError(err) => {
+                    RaidenError::InternalServerError(err.to_string())
+                }
+                TransactGetItemsError::InvalidEndpointException(err) => {
+                    RaidenError::InternalServerError(err.to_string())
+                }
+                TransactGetItemsError::ProvisionedThroughputExceededException(err) => {
+                    RaidenError::ProvisionedThroughputExceeded(err.to_string())
+                }
+                TransactGetItemsError::RequestLimitExceeded(err) => {
+                    RaidenError::RequestLimitExceeded(err.to_string())
+                }
+                TransactGetItemsError::ResourceNotFoundException(err) => {
+                    RaidenError::ResourceNotFound(err.to_string())
+                }
+                TransactGetItemsError::ThrottlingException(err) => {
+                    RaidenError::RequestLimitExceeded(err.to_string())
+                }
+                TransactGetItemsError::TransactionCanceledException(err) => {
+                    let reasons = RaidenTransactionCancellationReasons::from_str(
+                        err.message
+                            .clone()
+                            .unwrap_or_else(|| "transaction canceled".to_owned())
+                            .as_str(),
+                    );
+                    let raw_reasons = err.cancellation_reasons.clone().unwrap_or_default();
+
+                    RaidenError::TransactionCanceled {
+                        reasons,
+                        raw_reasons,
+                    }
                 }
                 _ => into_raiden_error(error),
             },

--- a/raiden/src/aws_sdk/ops/batch_put.rs
+++ b/raiden/src/aws_sdk/ops/batch_put.rs
@@ -1,0 +1,115 @@
+use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+
+use crate::ops::batch_put::BatchPutOutput;
+
+impl Serialize for BatchPutOutput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("BatchPutOutput", 2)?;
+        state.serialize_field(
+            "consumed_capacity",
+            &self.consumed_capacity.as_ref().map(|v| {
+                v.iter()
+                    .map(crate::aws_sdk::serialize::consumed_capacity_to_value)
+                    .collect::<Vec<_>>()
+            }),
+        )?;
+        state.serialize_field(
+            "unprocessed_items",
+            &self
+                .unprocessed_items
+                .iter()
+                .map(crate::aws_sdk::serialize::put_request_to_value)
+                .collect::<Vec<_>>(),
+        )?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for BatchPutOutput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum Field {
+            ConsumedCapacity,
+            UnprocessedItems,
+        }
+
+        const FIELDS: &[&str] = &["consumed_capacity", "unprocessed_items"];
+
+        struct BatchPutOutputVisitor;
+
+        impl<'de> Visitor<'de> for BatchPutOutputVisitor {
+            type Value = BatchPutOutput;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct BatchPutOutput")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut consumed_capacity = None;
+                let mut unprocessed_items = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::ConsumedCapacity => {
+                            if consumed_capacity.is_some() {
+                                return Err(de::Error::duplicate_field("consumed_capacity"));
+                            }
+
+                            let vs: Option<Vec<serde_json::Value>> = map.next_value()?;
+
+                            consumed_capacity = if let Some(vs) = vs {
+                                let mut values = vec![];
+
+                                for v in vs {
+                                    values.push(
+                                        crate::aws_sdk::serialize::value_to_consumed_capacity(v)
+                                            .map_err(de::Error::custom)?,
+                                    );
+                                }
+
+                                Some(values)
+                            } else {
+                                None
+                            };
+                        }
+                        Field::UnprocessedItems => {
+                            if unprocessed_items.is_some() {
+                                return Err(de::Error::duplicate_field("unprocessed_items"));
+                            }
+
+                            let vs: Vec<serde_json::Value> = map.next_value()?;
+                            let mut values = vec![];
+
+                            for v in vs {
+                                values.push(
+                                    crate::aws_sdk::serialize::value_to_put_request(v)
+                                        .map_err(de::Error::custom)?,
+                                );
+                            }
+
+                            unprocessed_items = Some(values);
+                        }
+                    }
+                }
+
+                Ok(BatchPutOutput {
+                    consumed_capacity,
+                    unprocessed_items: unprocessed_items.unwrap_or_default(),
+                })
+            }
+        }
+
+        deserializer.deserialize_struct("BatchPutOutput", FIELDS, BatchPutOutputVisitor)
+    }
+}

--- a/raiden/src/aws_sdk/ops/mod.rs
+++ b/raiden/src/aws_sdk/ops/mod.rs
@@ -1,9 +1,11 @@
 mod batch_delete;
 mod batch_get;
+mod batch_put;
 mod get;
 mod put;
 mod query;
 mod scan;
+mod transact_get;
 mod transact_write;
 mod update;
 

--- a/raiden/src/aws_sdk/ops/transact_get.rs
+++ b/raiden/src/aws_sdk/ops/transact_get.rs
@@ -1,0 +1,59 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+
+use crate::ops::transact_get::TransactGetOutput;
+
+impl<T> Serialize for TransactGetOutput<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("TransactGetOutput", 2)?;
+        state.serialize_field(
+            "consumed_capacity",
+            &self.consumed_capacity.as_ref().map(|v| {
+                v.iter()
+                    .map(crate::aws_sdk::serialize::consumed_capacity_to_value)
+                    .collect::<Vec<_>>()
+            }),
+        )?;
+        state.serialize_field("items", &self.items)?;
+        state.end()
+    }
+}
+
+impl<'de, T> Deserialize<'de> for TransactGetOutput<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct Helper<T> {
+            consumed_capacity: Option<Vec<serde_json::Value>>,
+            items: Vec<Option<T>>,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        let consumed_capacity = helper
+            .consumed_capacity
+            .map(|values| {
+                values
+                    .into_iter()
+                    .map(crate::aws_sdk::serialize::value_to_consumed_capacity)
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()
+            .map_err(serde::de::Error::custom)?;
+
+        Ok(TransactGetOutput {
+            consumed_capacity,
+            items: helper.items,
+        })
+    }
+}

--- a/raiden/src/aws_sdk/serialize/mod.rs
+++ b/raiden/src/aws_sdk/serialize/mod.rs
@@ -3,10 +3,11 @@ mod consumed_capacity;
 mod delete_request;
 mod item_collection_metrics;
 mod keys_and_attributes;
+mod put_request;
 
 pub use self::{
     attribute_value::*, consumed_capacity::*, delete_request::*, item_collection_metrics::*,
-    keys_and_attributes::*,
+    keys_and_attributes::*, put_request::*,
 };
 
 macro_rules! set_optional_value {

--- a/raiden/src/aws_sdk/serialize/put_request.rs
+++ b/raiden/src/aws_sdk/serialize/put_request.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use serde::de::{self, Error as _};
+use serde_json::{json, Error, Map, Value};
+
+use crate::aws_sdk::{
+    serialize::{attribute_value_to_value, set_optional_value, value_to_attribute_value},
+    types::PutRequest,
+};
+
+pub fn put_request_to_value(v: &PutRequest) -> Value {
+    json!({
+        "item": v.item.iter().map(|(k, v)| {
+            (k.clone(), attribute_value_to_value(v))
+        }).collect::<HashMap<String, Value>>(),
+    })
+}
+
+pub fn value_to_put_request(value: Value) -> Result<PutRequest, Error> {
+    if let Value::Object(m) = value {
+        let mut builder = PutRequest::builder();
+
+        set_optional_value!(builder, m, item, object, |m: &Map<_, _>| -> Result<_, _> {
+            let mut map = HashMap::new();
+
+            for (k, v) in m.iter() {
+                let v = value_to_attribute_value(v.clone())
+                    .map_err(|err| de::Error::custom(format!("{k} set in item: {err}")))?;
+
+                map.insert(k.clone(), v);
+            }
+
+            Ok(Some(map))
+        });
+
+        builder
+            .build()
+            .map_err(|err| Error::custom(err.to_string()))
+    } else {
+        Err(de::Error::custom("value is not type of PutRequest"))
+    }
+}

--- a/raiden/src/ops/batch_put.rs
+++ b/raiden/src/ops/batch_put.rs
@@ -1,0 +1,15 @@
+#[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
+use crate::{ConsumedCapacity, PutRequest};
+
+#[cfg(feature = "aws-sdk")]
+use crate::aws_sdk::types::{ConsumedCapacity, PutRequest};
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[cfg_attr(
+    any(feature = "rusoto", feature = "rusoto_rustls"),
+    derive(serde::Deserialize, serde::Serialize)
+)]
+pub struct BatchPutOutput {
+    pub consumed_capacity: Option<Vec<ConsumedCapacity>>,
+    pub unprocessed_items: Vec<PutRequest>,
+}

--- a/raiden/src/ops/mod.rs
+++ b/raiden/src/ops/mod.rs
@@ -1,9 +1,11 @@
 pub mod batch_delete;
 pub mod batch_get;
+pub mod batch_put;
 pub mod get;
 pub mod put;
 pub mod query;
 pub mod scan;
+pub mod transact_get;
 pub mod transact_write;
 pub mod update;
 

--- a/raiden/src/ops/transact_get.rs
+++ b/raiden/src/ops/transact_get.rs
@@ -1,0 +1,15 @@
+#[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
+use crate::ConsumedCapacity;
+
+#[cfg(feature = "aws-sdk")]
+use crate::aws_sdk::types::ConsumedCapacity;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[cfg_attr(
+    any(feature = "rusoto", feature = "rusoto_rustls"),
+    derive(serde::Deserialize, serde::Serialize)
+)]
+pub struct TransactGetOutput<T> {
+    pub consumed_capacity: Option<Vec<ConsumedCapacity>>,
+    pub items: Vec<Option<T>>,
+}

--- a/raiden/src/rusoto/errors.rs
+++ b/raiden/src/rusoto/errors.rs
@@ -207,3 +207,27 @@ impl From<RusotoError<TransactWriteItemsError>> for RaidenError {
         }
     }
 }
+
+impl From<RusotoError<TransactGetItemsError>> for RaidenError {
+    fn from(error: RusotoError<TransactGetItemsError>) -> Self {
+        match error {
+            RusotoError::Service(error) => match error {
+                TransactGetItemsError::InternalServerError(msg) => {
+                    RaidenError::InternalServerError(msg)
+                }
+                TransactGetItemsError::ProvisionedThroughputExceeded(msg) => {
+                    RaidenError::ProvisionedThroughputExceeded(msg)
+                }
+                TransactGetItemsError::RequestLimitExceeded(msg) => {
+                    RaidenError::RequestLimitExceeded(msg)
+                }
+                TransactGetItemsError::ResourceNotFound(msg) => RaidenError::ResourceNotFound(msg),
+                TransactGetItemsError::TransactionCanceled(msg) => {
+                    let reasons = RaidenTransactionCancellationReasons::from_str(&msg);
+                    RaidenError::TransactionCanceled { reasons }
+                }
+            },
+            _ => into_raiden_error(error),
+        }
+    }
+}

--- a/raiden/tests/all/batch_put.rs
+++ b/raiden/tests/all/batch_put.rs
@@ -1,0 +1,188 @@
+#[cfg(test)]
+mod partition_key_tests {
+    use pretty_assertions::assert_eq;
+    use raiden::*;
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    pub struct BatchPutTest0 {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+    }
+
+    #[tokio::test]
+    async fn test_batch_put_item() {
+        let client = crate::all::create_client_from_struct!(BatchPutTest0);
+        let items = (0..3)
+            .map(|i| {
+                BatchPutTest0::put_item_builder()
+                    .id(format!("put-id{i}"))
+                    .name("bob".to_owned())
+                    .build()
+            })
+            .collect();
+
+        let res = client.batch_put(items).run().await.unwrap();
+
+        assert_eq!(
+            res,
+            batch_put::BatchPutOutput {
+                consumed_capacity: None,
+                unprocessed_items: vec![],
+            }
+        );
+
+        let got = client.get("put-id0").run().await.unwrap();
+        assert_eq!(
+            got.item,
+            BatchPutTest0 {
+                id: "put-id0".to_owned(),
+                name: "bob".to_owned(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_put_over_25_items() {
+        let client = crate::all::create_client_from_struct!(BatchPutTest0);
+        let items = (0..40)
+            .map(|i| {
+                BatchPutTest0::put_item_builder()
+                    .id(format!("put-over-id{i}"))
+                    .name("bob".to_owned())
+                    .build()
+            })
+            .collect();
+
+        let res = client.batch_put(items).run().await;
+
+        assert!(res.is_ok());
+
+        let first = client.get("put-over-id0").run().await.unwrap();
+        let last = client.get("put-over-id39").run().await.unwrap();
+
+        assert_eq!(
+            first.item,
+            BatchPutTest0 {
+                id: "put-over-id0".to_owned(),
+                name: "bob".to_owned(),
+            }
+        );
+        assert_eq!(
+            last.item,
+            BatchPutTest0 {
+                id: "put-over-id39".to_owned(),
+                name: "bob".to_owned(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_put_overwrites_existing_items() {
+        let client = crate::all::create_client_from_struct!(BatchPutTest0);
+        let initial = BatchPutTest0::put_item_builder()
+            .id("put-overwrite-id".to_owned())
+            .name("before".to_owned())
+            .build();
+        let updated = BatchPutTest0::put_item_builder()
+            .id("put-overwrite-id".to_owned())
+            .name("after".to_owned())
+            .build();
+
+        client.batch_put(vec![initial]).run().await.unwrap();
+        client.batch_put(vec![updated]).run().await.unwrap();
+
+        let got = client.get("put-overwrite-id").run().await.unwrap();
+        assert_eq!(
+            got.item,
+            BatchPutTest0 {
+                id: "put-overwrite-id".to_owned(),
+                name: "after".to_owned(),
+            }
+        );
+    }
+}
+
+#[cfg(test)]
+mod partition_key_and_sort_key_tests {
+    use raiden::*;
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    pub struct BatchPutTest1 {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        #[raiden(sort_key)]
+        year: usize,
+    }
+
+    #[tokio::test]
+    async fn test_batch_put_item_with_sort_key() {
+        let client = crate::all::create_client_from_struct!(BatchPutTest1);
+        let items = (0..3)
+            .map(|i| {
+                BatchPutTest1::put_item_builder()
+                    .id(format!("put-sk-id{i}"))
+                    .name("bob".to_owned())
+                    .year(2000 + i)
+                    .build()
+            })
+            .collect();
+
+        assert!(client.batch_put(items).run().await.is_ok());
+
+        let got = client.get("put-sk-id0", 2000_usize).run().await.unwrap();
+        assert_eq!(
+            got.item,
+            BatchPutTest1 {
+                id: "put-sk-id0".to_owned(),
+                name: "bob".to_owned(),
+                year: 2000,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_put_with_sort_key_over_25_items() {
+        let client = crate::all::create_client_from_struct!(BatchPutTest1);
+        let items = (0..40)
+            .map(|i| {
+                BatchPutTest1::put_item_builder()
+                    .id(format!("put-sk-over-id{i}"))
+                    .name("bob".to_owned())
+                    .year(3000 + i)
+                    .build()
+            })
+            .collect();
+
+        client.batch_put(items).run().await.unwrap();
+
+        let first = client
+            .get("put-sk-over-id0", 3000_usize)
+            .run()
+            .await
+            .unwrap();
+        let last = client
+            .get("put-sk-over-id39", 3039_usize)
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first.item,
+            BatchPutTest1 {
+                id: "put-sk-over-id0".to_owned(),
+                name: "bob".to_owned(),
+                year: 3000,
+            }
+        );
+        assert_eq!(
+            last.item,
+            BatchPutTest1 {
+                id: "put-sk-over-id39".to_owned(),
+                name: "bob".to_owned(),
+                year: 3039,
+            }
+        );
+    }
+}

--- a/raiden/tests/all/mod.rs
+++ b/raiden/tests/all/mod.rs
@@ -1,5 +1,6 @@
 mod batch_delete;
 mod batch_get;
+mod batch_put;
 mod condition;
 mod delete;
 mod document;
@@ -11,6 +12,7 @@ mod query;
 mod rename;
 mod rename_all;
 mod scan;
+mod transact_get;
 mod transact_write;
 mod update;
 

--- a/raiden/tests/all/transact_get.rs
+++ b/raiden/tests/all/transact_get.rs
@@ -1,0 +1,150 @@
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use raiden::*;
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    pub struct BatchTest0 {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+    }
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    pub struct BatchTest1 {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        #[raiden(sort_key)]
+        year: usize,
+    }
+
+    #[tokio::test]
+    async fn test_transact_get_items() {
+        let client = crate::all::create_client_from_struct!(BatchTest0);
+        let res = client
+            .transact_get(vec!["id0", "id1", "unstored"])
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(res.items.len(), 3);
+        assert_eq!(
+            res.items[0],
+            Some(BatchTest0 {
+                id: "id0".to_owned(),
+                name: "bob".to_owned(),
+            })
+        );
+        assert_eq!(res.items[2], None);
+    }
+
+    #[tokio::test]
+    async fn test_transact_get_items_preserves_request_order() {
+        let client = crate::all::create_client_from_struct!(BatchTest0);
+        let res = client
+            .transact_get(vec!["id2", "unstored", "id0", "id1"])
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            res.items,
+            vec![
+                Some(BatchTest0 {
+                    id: "id2".to_owned(),
+                    name: "bob".to_owned(),
+                }),
+                None,
+                Some(BatchTest0 {
+                    id: "id0".to_owned(),
+                    name: "bob".to_owned(),
+                }),
+                Some(BatchTest0 {
+                    id: "id1".to_owned(),
+                    name: "bob".to_owned(),
+                }),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transact_get_items_with_sort_key() {
+        let client = crate::all::create_client_from_struct!(BatchTest1);
+        let res = client
+            .transact_get(vec![("id0", 2000_usize), ("id1", 2001_usize)])
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(res.items.len(), 2);
+        assert_eq!(
+            res.items[0],
+            Some(BatchTest1 {
+                id: "id0".to_owned(),
+                name: "bob".to_owned(),
+                year: 2000,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transact_get_items_with_sort_key_and_missing_item() {
+        let client = crate::all::create_client_from_struct!(BatchTest1);
+        let res = client
+            .transact_get(vec![
+                ("id1", 2001_usize),
+                ("id1", 2000_usize),
+                ("id2", 2002_usize),
+            ])
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            res.items,
+            vec![
+                Some(BatchTest1 {
+                    id: "id1".to_owned(),
+                    name: "bob".to_owned(),
+                    year: 2001,
+                }),
+                None,
+                Some(BatchTest1 {
+                    id: "id2".to_owned(),
+                    name: "bob".to_owned(),
+                    year: 2002,
+                }),
+            ]
+        );
+    }
+
+    #[derive(Raiden, Debug, Clone, PartialEq)]
+    #[raiden(table_name = "BatchTest1")]
+    pub struct BatchTest1Projection {
+        #[raiden(partition_key)]
+        id: String,
+        name: String,
+        #[raiden(sort_key)]
+        year: usize,
+    }
+
+    #[tokio::test]
+    async fn test_transact_get_items_uses_projection_expression() {
+        let client = crate::all::create_client_from_struct!(BatchTest1Projection);
+        let res = client
+            .transact_get(vec![("id0", 2000_usize)])
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            res.items,
+            vec![Some(BatchTest1Projection {
+                id: "id0".to_owned(),
+                name: "bob".to_owned(),
+                year: 2000,
+            })]
+        );
+    }
+}

--- a/setup/fixtures/batch_put_test_0.ts
+++ b/setup/fixtures/batch_put_test_0.ts
@@ -1,0 +1,11 @@
+import type { CreateAndPut } from "../dynamo_util.ts";
+
+export const batchPutTest0: CreateAndPut = {
+  table: {
+    TableName: "BatchPutTest0",
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  },
+  items: [],
+};

--- a/setup/fixtures/batch_put_test_1.ts
+++ b/setup/fixtures/batch_put_test_1.ts
@@ -1,0 +1,17 @@
+import type { CreateAndPut } from "../dynamo_util.ts";
+
+export const batchPutTest1: CreateAndPut = {
+  table: {
+    TableName: "BatchPutTest1",
+    KeySchema: [
+      { AttributeName: "id", KeyType: "HASH" },
+      { AttributeName: "year", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "id", AttributeType: "S" },
+      { AttributeName: "year", AttributeType: "N" },
+    ],
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  },
+  items: [],
+};

--- a/setup/setup.ts
+++ b/setup/setup.ts
@@ -1,6 +1,8 @@
 import { DynamoDBClient } from "./deps.ts";
 import { batchDeleteTest0 } from "./fixtures/batch_delete_test_0.ts";
 import { batchDeleteTest1 } from "./fixtures/batch_delete_test_1.ts";
+import { batchPutTest0 } from "./fixtures/batch_put_test_0.ts";
+import { batchPutTest1 } from "./fixtures/batch_put_test_1.ts";
 import { batchTest0 } from "./fixtures/batch_test_0.ts";
 import { batchTest1 } from "./fixtures/batch_test_1.ts";
 import { batchTest2 } from "./fixtures/batch_test_2.ts";
@@ -48,6 +50,8 @@ const client = new DynamoDBClient({
 const data = [
   batchDeleteTest0,
   batchDeleteTest1,
+  batchPutTest0,
+  batchPutTest1,
   batchTest0,
   batchTest1,
   batchTest2,


### PR DESCRIPTION
## Summary
- Add typed BatchPut support for rusoto and aws-sdk clients, including BatchWriteItem PutRequest serialization and 25-item chunking/retry handling.
- Add typed TransactGetItems support for rusoto and aws-sdk clients, preserving request order and returning missing items as None.
- Update README examples/API support checklist and add broader integration coverage for batch put and transact get paths.

## Tests
- cargo fmt --check
- cargo test -p raiden --no-run
- CARGO_TARGET_DIR=/private/tmp/raiden-aws-target cargo test -p raiden --no-default-features --features aws-sdk,tracing --no-run
- AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy cargo test -p raiden batch_put -- --test-threads=1 was attempted, but local DynamoDB was not running: Connection refused (os error 61).