### PR TITLE
Add non-breaking ConversionError message helper

### DIFF
--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -122,6 +122,18 @@ pub enum ConversionError {
     Serde(String),
 }
 
+impl ConversionError {
+    /// Creates a conversion error with a descriptive message.
+    ///
+    /// This is a non-breaking helper for callers that need to preserve validation
+    /// or parsing details from custom `FromAttribute` implementations. The
+    /// message is stored in the existing `Serde` variant to avoid adding a new
+    /// public enum variant.
+    pub fn message(message: impl Into<String>) -> Self {
+        ConversionError::Serde(message.into())
+    }
+}
+
 impl std::fmt::Display for ConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -252,4 +264,17 @@ pub fn merge_map<T>(
     map2: std::collections::HashMap<String, T>,
 ) -> std::collections::HashMap<String, T> {
     map1.into_iter().chain(map2).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_error_message_preserves_context() {
+        let error = ConversionError::message("custom validation failed");
+
+        assert_eq!("custom validation failed", error.to_string());
+        assert!(matches!(error, ConversionError::Serde(_)));
+    }
 }


### PR DESCRIPTION
## Summary

Adds `ConversionError::message(...)` as a non-breaking helper for custom `FromAttribute` implementations that need to preserve validation or parsing context.

This intentionally reuses the existing `ConversionError::Serde(String)` variant instead of adding a new public enum variant, because adding a variant to a public enum can break downstream exhaustive matches.

## Motivation

Some domain models validate persisted DynamoDB values during `FromAttribute`. When validation fails, callers currently tend to fall back to `ConversionError::ValueIsNone`, which loses the actual reason. This helper gives those implementations a clear API for returning a descriptive error while preserving the existing enum shape.

## Compatibility

- No new public enum variant is added.
- Existing `RaidenError::AttributeConvertError { attr_name }` behavior generated by derives is unchanged.
- Existing pattern matches on `ConversionError` variants are not affected.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p raiden`
- `cargo test -p raiden conversion_error_message_preserves_context`
