### PR TITLE
Fix derived null checks for downstream crates

### DIFF
--- a/raiden-derive/src/item.rs
+++ b/raiden-derive/src/item.rs
@@ -57,12 +57,7 @@ fn expand_raiden_item_impl_from_fields(
                         Default::default()
                     } else {
                         let item = item.unwrap();
-                        #[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
-                        let is_null = Some(true) == item.null;
-                        #[cfg(feature = "aws-sdk")]
-                        let is_null = item.is_null();
-
-                        if is_null {
+                        if ::raiden::is_null_attribute_value(&item) {
                             Default::default()
                         } else {
                             let converted = ::raiden::FromAttribute::from_attr(Some(item));

--- a/raiden/src/lib.rs
+++ b/raiden/src/lib.rs
@@ -103,6 +103,26 @@ pub trait IntoAttribute: Sized {
     fn into_attr(self) -> AttributeValue;
 }
 
+/// Returns whether a DynamoDB attribute represents `NULL`.
+///
+/// Derive macros call this helper from generated code so the null check is
+/// resolved inside the `raiden` crate. This avoids depending on feature flags
+/// in the downstream crate where the macro is expanded.
+#[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
+pub fn is_null_attribute_value(value: &AttributeValue) -> bool {
+    Some(true) == value.null
+}
+
+/// Returns whether a DynamoDB attribute represents `NULL`.
+///
+/// Derive macros call this helper from generated code so the null check is
+/// resolved inside the `raiden` crate. This avoids depending on feature flags
+/// in the downstream crate where the macro is expanded.
+#[cfg(feature = "aws-sdk")]
+pub fn is_null_attribute_value(value: &AttributeValue) -> bool {
+    value.is_null()
+}
+
 /// Marker trait for types that should be serialized as DynamoDB documents.
 ///
 /// This trait is typically implemented via `#[derive(RaidenDocument)]`.


### PR DESCRIPTION
## Summary
- add a public raiden helper for checking DynamoDB NULL attributes behind the selected backend feature
- update Raiden derive output to call the helper instead of emitting downstream crate feature-gated local bindings

## Why
`#[raiden(use_default)]` currently expands `#[cfg(feature = "aws-sdk")] let is_null = ...` into the consuming crate. Downstream crates that depend on raiden with the `aws-sdk` feature do not necessarily define their own `aws-sdk` feature, so the generated code can fail with `cannot find value is_null in this scope`.

This keeps the API additive and avoids a breaking change.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p raiden --no-default-features --features aws-sdk`