### PR TITLE
Handle empty BatchGet keys without calling DynamoDB

### DIFF
--- a/raiden-derive/src/aws_sdk/ops/batch_get.rs
+++ b/raiden-derive/src/aws_sdk/ops/batch_get.rs
@@ -108,6 +108,16 @@ pub(crate) fn expand_batch_get(
     };
 
     let api_call_token = super::api_call_token!("batch_get_item");
+    let empty_keys_warning = if cfg!(feature = "tracing") {
+        quote! {
+            ::tracing::warn!(
+                table_name = %self.table_name,
+                "batch_get called with empty keys; returning an empty output"
+            );
+        }
+    } else {
+        quote! {}
+    };
     let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
         (
             quote! { #builder_name::inner_run(&self.table_name, &self.client, builder).await? },
@@ -142,6 +152,15 @@ pub(crate) fn expand_batch_get(
                     .set_keys(Some(vec![]))
                     .build()
                     .expect("should be built");
+
+                if self.keys.is_empty() {
+                    #empty_keys_warning
+                    return Ok(::raiden::batch_get::BatchGetOutput {
+                        consumed_capacity: None,
+                        items,
+                        unprocessed_keys: Some(unprocessed_keys),
+                    });
+                }
 
                 // TODO: for now set 5, however we should make it more flexible.
                 let mut unprocessed_retry = 5;

--- a/raiden-derive/src/rusoto/ops/batch_get.rs
+++ b/raiden-derive/src/rusoto/ops/batch_get.rs
@@ -112,6 +112,16 @@ pub(crate) fn expand_batch_get(
     };
 
     let api_call_token = super::api_call_token!("batch_get_item");
+    let empty_keys_warning = if cfg!(feature = "tracing") {
+        quote! {
+            ::tracing::warn!(
+                %table_name,
+                "batch_get called with empty keys; returning an empty output"
+            );
+        }
+    } else {
+        quote! {}
+    };
     let (call_inner_run, inner_run_args) = if cfg!(feature = "tracing") {
         (
             quote! { #builder_name::inner_run(table_name, client, input).await },
@@ -145,6 +155,15 @@ pub(crate) fn expand_batch_get(
                 let policy: ::raiden::RetryPolicy = policy.into();
                 let mut items: std::vec::Vec<#struct_name> = vec![];
                 let mut unprocessed_keys = ::raiden::KeysAndAttributes::default();
+
+                if keys.is_empty() {
+                    #empty_keys_warning
+                    return Ok(::raiden::batch_get::BatchGetOutput {
+                        consumed_capacity: None,
+                        items,
+                        unprocessed_keys: Some(unprocessed_keys),
+                    });
+                }
 
                 // TODO: for now set 5, however we should make it more flexible.
                 let mut unprocessed_retry = 5;

--- a/raiden/tests/all/batch_get.rs
+++ b/raiden/tests/all/batch_get.rs
@@ -56,6 +56,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_batch_get_item_empty_keys() {
+        let client = crate::all::create_client_from_struct!(BatchTest0);
+        let res: batch_get::BatchGetOutput<BatchTest0> =
+            client.batch_get(Vec::<String>::new()).run().await.unwrap();
+
+        assert_eq!(
+            res,
+            batch_get::BatchGetOutput {
+                items: vec![],
+                consumed_capacity: None,
+                unprocessed_keys: Some(crate::all::default_key_and_attributes()),
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn test_batch_get_item_extended() {
         let client = crate::all::create_client_from_struct!(BatchTest0);
         let keys: Vec<String> = (0..101).map(|n| format!("id{n}")).collect();
@@ -144,6 +160,25 @@ mod tests {
             sort_by_id_1(res),
             batch_get::BatchGetOutput {
                 items: expected_items,
+                consumed_capacity: None,
+                unprocessed_keys: Some(crate::all::default_key_and_attributes()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_item_sort_key_empty_keys() {
+        let client = crate::all::create_client_from_struct!(BatchTest1);
+        let res: batch_get::BatchGetOutput<BatchTest1> = client
+            .batch_get(Vec::<(String, usize)>::new())
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            res,
+            batch_get::BatchGetOutput {
+                items: vec![],
                 consumed_capacity: None,
                 unprocessed_keys: Some(crate::all::default_key_and_attributes()),
             }


### PR DESCRIPTION
## What does this change?

`batch_get` now returns an empty `BatchGetOutput` immediately when called with an empty key list instead of sending an invalid `Keys: []` request to DynamoDB.

When the `tracing` feature is enabled, the early return emits a warning containing the table name. The behavior is implemented consistently for both the AWS SDK and Rusoto backends.

Regression tests cover empty key lists for tables with a partition key only and tables with a composite key.

## Why?

DynamoDB rejects an empty `BatchGetItem` key list with a validation error. Empty collections are a natural result of upstream filtering, so callers should not all need to add their own guard before using the batch API.

## What can I check for bug fixes?

- `batch_get(Vec::<String>::new())` returns an empty output without contacting DynamoDB.
- `batch_get(Vec::<(String, usize)>::new())` behaves the same for composite keys.
- With `tracing` enabled, the empty-input path logs a warning.

## Validation

- `cargo +1.88.0 fmt --all -- --check`
- `RUSTUP_TOOLCHAIN=1.88.0 make lint`
- AWS SDK empty-key tests with Rust 1.88
- Rusoto empty-key tests with Rust 1.88
- `cargo +1.88.0 check --no-default-features --features aws-sdk,tracing`
- `cargo +1.88.0 check --no-default-features --features rusoto,tracing`
